### PR TITLE
Feat/calendar component

### DIFF
--- a/packages/app/features/calendar/components/Calendar.tsx
+++ b/packages/app/features/calendar/components/Calendar.tsx
@@ -161,17 +161,22 @@ export function Calendar<TEvent = unknown>({
           />
         )}
 
-        {weekDays.map((day, dayIndex) => (
-          <CalendarDayHeader
-            key={`header-${dayIndex}`}
-            day={day}
-            dayIndex={dayIndex}
-            isActive={dayIndex === currentDayIndex}
-            isLast={dayIndex === weekDays.length - 1}
-            showGridLines={showGridLines}
-            tokens={headerTokens}
-          />
-        ))}
+        {weekDays.map((day, dayIndex) => {
+          const isActive = dayIndex === currentDayIndex;
+          const isLast = dayIndex === weekDays.length - 1;
+          
+          return (
+            <CalendarDayHeader
+              key={`header-${dayIndex}`}
+              day={day}
+              dayIndex={dayIndex}
+              isActive={isActive}
+              isLast={isLast}
+              showGridLines={showGridLines}
+              tokens={headerTokens}
+            />
+          );
+        })}
       </XStack>
 
       <YStack
@@ -197,19 +202,24 @@ export function Calendar<TEvent = unknown>({
             />
           )}
 
-          {weekDays.map((_day, dayIndex) => (
-            <CalendarColumn
-              key={`col-${dayIndex}`}
-              dayIndex={dayIndex}
-              events={eventsByDay.get(dayIndex) ?? []}
-              rowModels={rowModels}
-              isLast={dayIndex === weekDays.length - 1}
-              isActive={dayIndex === currentDayIndex}
-              showGridLines={showGridLines}
-              showTimelineGrid={showTimelineGrid}
-              config={columnConfig}
-            />
-          ))}
+          {weekDays.map((_day, dayIndex) => {
+            const isActive = dayIndex === currentDayIndex;
+            const isLast = dayIndex === weekDays.length - 1;
+            
+            return (
+              <CalendarColumn
+                key={`col-${dayIndex}`}
+                dayIndex={dayIndex}
+                events={eventsByDay.get(dayIndex) ?? []}
+                rowModels={rowModels}
+                isLast={isLast}
+                isActive={isActive}
+                showGridLines={showGridLines}
+                showTimelineGrid={showTimelineGrid}
+                config={columnConfig}
+              />
+            );
+          })}
         </XStack>
       </YStack>
     </YStack>

--- a/packages/app/features/calendar/components/Calendar.tsx
+++ b/packages/app/features/calendar/components/Calendar.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { XStack, YStack } from '@mezon-tutors/app/ui';
+import { CALENDAR_CONFIG, CALENDAR_THEME_CONFIG, DEFAULT_THEME_CONFIG } from '@mezon-tutors/shared';
+import dayjs from 'dayjs';
+import { useMemo } from 'react';
+import { useMedia } from 'tamagui';
+import type { BaseCalendarProps, CalendarEvent, CalendarType } from '../types';
+import { CalendarColumn, type CalendarColumnConfig } from './CalendarColumn';
+import { CalendarDayHeader, type CalendarDayHeaderTokens } from './CalendarDayHeader';
+import { CalendarGridLayer, type CalendarGridLayerProps } from './CalendarGridLayer';
+import { buildRowModels, CalendarLayoutEngine } from './utils';
+
+function formatHour(hour: number): string {
+  return dayjs().hour(hour).minute(0).format('HH:mm');
+}
+
+function formatRangeLabel(startHour: number, endHour: number): string {
+  return `${formatHour(startHour)} - ${formatHour(endHour)}`;
+}
+
+export function Calendar<TEvent = unknown>({
+  type,
+  weekDays,
+  weekHours,
+  events = [],
+  currentDayIndex,
+  currentHour,
+  enableGapCollapse = false,
+  minGapHours = CALENDAR_CONFIG.MIN_GAP_HOURS,
+  readonly = false,
+  onSlotClick,
+  renderEvent,
+  renderSlot,
+  themePrefix = 'calendar',
+  isCompact: isCompactProp,
+}: BaseCalendarProps<TEvent>) {
+  const media = useMedia();
+  const isCompact = isCompactProp ?? (media.md || media.sm || media.xs);
+
+  const resolvedThemePrefix = type ?? themePrefix;
+  const themeConfig = CALENDAR_THEME_CONFIG[resolvedThemePrefix] ?? DEFAULT_THEME_CONFIG;
+  const { showTimeline, showGridLines, showNowLine } = themeConfig;
+  const showTimelineGrid = themeConfig.showTimelineGrid ?? showGridLines;
+  const showDayColumnGridLines = themeConfig.showDayColumnGridLines ?? showGridLines;
+  const showGridOuterBorder = themeConfig.showGridOuterBorder ?? showGridLines;
+
+  const timeColumnWidth = isCompact
+    ? CALENDAR_CONFIG.TIME_COLUMN_WIDTH.COMPACT
+    : CALENDAR_CONFIG.TIME_COLUMN_WIDTH.NORMAL;
+  const defaultRowHeight = isCompact
+    ? CALENDAR_CONFIG.ROW_HEIGHT.COMPACT
+    : CALENDAR_CONFIG.ROW_HEIGHT.NORMAL;
+  const defaultGapRowHeight = isCompact
+    ? CALENDAR_CONFIG.GAP_ROW_HEIGHT.COMPACT
+    : CALENDAR_CONFIG.GAP_ROW_HEIGHT.NORMAL;
+  const rowHeight = themeConfig.rowHeight ?? defaultRowHeight;
+  const gapRowHeight = themeConfig.gapRowHeight ?? defaultGapRowHeight;
+  const slotPadding = isCompact ? 6 : 8;
+  const eventPadding = themeConfig.eventPadding ?? slotPadding;
+  const eventTopPadding = themeConfig.eventTopPadding ?? eventPadding;
+
+  const rowModels = useMemo(
+    () => buildRowModels(weekHours, events, currentHour, enableGapCollapse, minGapHours),
+    [weekHours, events, currentHour, enableGapCollapse, minGapHours]
+  );
+
+  const layoutEngine = useMemo(
+    () => new CalendarLayoutEngine(rowModels, { rowHeight, gapRowHeight }),
+    [rowModels, rowHeight, gapRowHeight]
+  );
+
+  const eventsByDay = useMemo(() => {
+    const grouped = new Map<number, CalendarEvent<TEvent>[]>();
+    events.forEach((event) => {
+      const items = grouped.get(event.dayIndex) ?? [];
+      items.push(event);
+      grouped.set(event.dayIndex, items);
+    });
+    return grouped;
+  }, [events]);
+
+  const headerBg = `$${resolvedThemePrefix}GridHeaderBackground`;
+  const bodyBg = `$${resolvedThemePrefix}GridBodyBackground`;
+  const gridBorder = `$${resolvedThemePrefix}GridBorder`;
+
+  const headerTokens: CalendarDayHeaderTokens = {
+    gridBorder,
+    activeDayColumn: `$${resolvedThemePrefix}ActiveDayColumn`,
+    dayLabel: `$${resolvedThemePrefix}DayLabel`,
+    activeDate: `$${resolvedThemePrefix}ActiveDate`,
+    inactiveDate: `$${resolvedThemePrefix}InactiveDate`,
+  };
+
+  const columnConfig: CalendarColumnConfig<TEvent> = {
+    layoutEngine,
+    rowHeight,
+    slotPadding,
+    eventPadding,
+    eventTopPadding,
+    readonly,
+    isCompact,
+    showNowLine,
+    currentHour,
+    headerHeight: CALENDAR_CONFIG.HEADER_HEIGHT,
+    onSlotClick,
+    renderEvent,
+    renderSlot,
+    themeTokens: {
+      gridBorder,
+      currentColumn: `$${resolvedThemePrefix}CurrentColumn`,
+      nowLine: `$${resolvedThemePrefix}NowLine`,
+      weekendLabel: `$${resolvedThemePrefix}DayLabel`,
+    },
+    weekendNoSlotDays: themeConfig.weekendNoSlotDays ?? [],
+    weekendNoSlotLabel: themeConfig.weekendNoSlotLabel,
+    emptySlotMergeHours: themeConfig.emptySlotMergeHours ?? 1,
+  };
+
+  const gridProps: CalendarGridLayerProps = {
+    rowModels,
+    layoutEngine,
+    showTimeline,
+    showGridLines,
+    showTimelineGrid,
+    showDayColumnGridLines,
+    timeColumnWidth,
+    rowHeight,
+    gapRowHeight,
+    formatHour,
+    formatRangeLabel,
+    themeTokens: {
+      gridBorder,
+      gapCellBg: `$${resolvedThemePrefix}GapCellBackground`,
+      gapLabel: `$${resolvedThemePrefix}GapLabel`,
+      gapHint: `$${resolvedThemePrefix}GapHint`,
+      timeLabel: `$${resolvedThemePrefix}TimeLabel`,
+    },
+    translationNamespace: themeConfig.translationNamespace ?? 'MySchedule',
+  };
+
+  return (
+    <YStack
+      borderWidth={showGridOuterBorder ? 1 : 0}
+      borderColor={showGridOuterBorder ? gridBorder : 'transparent'}
+      borderRadius={showGridOuterBorder ? 14 : 0}
+      overflow="hidden"
+      width="100%"
+    >
+      <XStack
+        width="100%"
+        minHeight={CALENDAR_CONFIG.HEADER_HEIGHT}
+        backgroundColor={headerBg}
+        paddingBottom={showGridLines ? 0 : 8}
+      >
+        {showTimeline && (
+          <YStack
+            width={timeColumnWidth}
+            borderRightWidth={showGridLines ? 1 : 0}
+            borderRightColor={gridBorder}
+          />
+        )}
+
+        {weekDays.map((day, dayIndex) => (
+          <CalendarDayHeader
+            key={`header-${dayIndex}`}
+            day={day}
+            dayIndex={dayIndex}
+            isActive={dayIndex === currentDayIndex}
+            isLast={dayIndex === weekDays.length - 1}
+            showGridLines={showGridLines}
+            tokens={headerTokens}
+          />
+        ))}
+      </XStack>
+
+      <YStack
+        width="100%"
+        height={layoutEngine.totalHeight}
+        position="relative"
+        backgroundColor={bodyBg}
+      >
+        <CalendarGridLayer {...gridProps} />
+
+        <XStack
+          width="100%"
+          height="100%"
+          position="absolute"
+          top={0}
+          left={0}
+          pointerEvents="box-none"
+        >
+          {showTimeline && (
+            <YStack
+              width={timeColumnWidth}
+              pointerEvents="none"
+            />
+          )}
+
+          {weekDays.map((_day, dayIndex) => (
+            <CalendarColumn
+              key={`col-${dayIndex}`}
+              dayIndex={dayIndex}
+              events={eventsByDay.get(dayIndex) ?? []}
+              rowModels={rowModels}
+              isLast={dayIndex === weekDays.length - 1}
+              isActive={dayIndex === currentDayIndex}
+              showGridLines={showGridLines}
+              showTimelineGrid={showTimelineGrid}
+              config={columnConfig}
+            />
+          ))}
+        </XStack>
+      </YStack>
+    </YStack>
+  );
+}

--- a/packages/app/features/calendar/components/CalendarCard.tsx
+++ b/packages/app/features/calendar/components/CalendarCard.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { YStack } from 'tamagui';
+import { CALENDAR_THEME_CONFIG, DEFAULT_THEME_CONFIG } from '@mezon-tutors/shared';
+import type { ReactNode } from 'react';
+import { Calendar } from './Calendar';
+import { buildDefaultRenderSlot } from './CalendarCardEmptySlots';
+import { resolveCardPresetRender } from './CalendarCardPresets';
+import type { BaseCalendarProps, CalendarPresetData, CalendarType } from '../types';
+
+type CalendarCardProps<TEvent> = BaseCalendarProps<TEvent> & {
+  header?: ReactNode;
+  footer?: ReactNode;
+  presetData?: CalendarPresetData;
+};
+
+export function CalendarCard<TEvent = unknown>({
+  header,
+  footer,
+  presetData,
+  type,
+  themePrefix = 'calendar',
+  renderSlot,
+  ...calendarProps
+}: CalendarCardProps<TEvent>) {
+  const resolvedThemePrefix = type ?? themePrefix;
+  const themeConfig = CALENDAR_THEME_CONFIG[resolvedThemePrefix] ?? DEFAULT_THEME_CONFIG;
+  const { cardBorder = true, cardBorderRadius = 16, cardPadding = 16 } = themeConfig;
+
+  const defaultRenderSlot = buildDefaultRenderSlot(resolvedThemePrefix, themeConfig);
+  const finalRenderSlot = renderSlot ?? defaultRenderSlot;
+
+  const presetResult =
+    !header && !footer && presetData
+      ? resolveCardPresetRender(resolvedThemePrefix as CalendarType, {
+          data: presetData,
+          isCompact: Boolean(calendarProps.isCompact),
+        })
+      : undefined;
+
+  return (
+    <YStack
+      width="100%"
+      borderWidth={cardBorder ? 1 : 0}
+      borderColor={cardBorder ? `$${resolvedThemePrefix}CardBorder` : 'transparent'}
+      borderRadius={cardBorderRadius}
+      backgroundColor={`$${resolvedThemePrefix}CardBackground`}
+      padding={cardPadding}
+      gap="$3"
+    >
+      {header ?? presetResult?.header}
+
+      <Calendar
+        {...calendarProps}
+        type={type}
+        themePrefix={resolvedThemePrefix}
+        renderSlot={finalRenderSlot}
+      />
+
+      {footer ?? presetResult?.footer}
+    </YStack>
+  );
+}

--- a/packages/app/features/calendar/components/CalendarCardEmptySlots.tsx
+++ b/packages/app/features/calendar/components/CalendarCardEmptySlots.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { Text, YStack } from 'tamagui';
+import type { CalendarThemeConfig } from '@mezon-tutors/shared';
+
+function DefaultEmptySlot({ text }: { text?: string }) {
+  if (!text) return null;
+
+  return (
+    <YStack
+      width="100%"
+      height="100%"
+      justifyContent="center"
+      alignItems="center"
+      opacity={0.5}
+    >
+      <Text
+        fontSize={11}
+        fontWeight="600"
+        color="$myScheduleDayLabel"
+        textTransform="uppercase"
+        letterSpacing={0.5}
+      >
+        {text}
+      </Text>
+    </YStack>
+  );
+}
+
+function OutlinedEmptySlot({
+  themePrefix,
+  text,
+  maxWidth,
+  minHeight,
+  borderRadius = 12,
+  borderStyle = 'dashed',
+}: {
+  themePrefix: string;
+  text?: string;
+  maxWidth?: number;
+  minHeight?: number;
+  borderRadius?: number;
+  borderStyle?: 'solid' | 'dashed';
+}) {
+  return (
+    <YStack
+      width="100%"
+      height="100%"
+      maxWidth={maxWidth}
+      borderRadius={borderRadius}
+      backgroundColor={`$${themePrefix}SlotEmptyBackground`}
+      borderWidth={1}
+      borderStyle={borderStyle}
+      borderColor={`$${themePrefix}SlotEmptyBorder`}
+      alignSelf="center"
+      justifyContent="center"
+      alignItems="center"
+      minHeight={minHeight}
+    >
+      {text ? (
+        <Text
+          fontSize={10}
+          fontWeight="700"
+          color={`$${themePrefix}SlotEmptyText`}
+          letterSpacing={0.6}
+        >
+          {text}
+        </Text>
+      ) : null}
+    </YStack>
+  );
+}
+
+function TutorScheduleEmptySlot({ themePrefix }: { themePrefix: string }) {
+  return (
+    <YStack
+      width="100%"
+      height="auto"
+      maxWidth={110}
+      maxHeight={60}
+      borderRadius={12}
+      backgroundColor={`$${themePrefix}SlotEmptyBackground`}
+      borderWidth={1}
+      borderColor={`$${themePrefix}SlotEmptyBorder`}
+      alignSelf="center"
+      minHeight={56}
+    />
+  );
+}
+
+export function buildDefaultRenderSlot(themePrefix: string, themeConfig: CalendarThemeConfig) {
+  if (!themeConfig.showEmptySlots) return undefined;
+
+  if (themePrefix === 'tutorSchedule') {
+    return () => <TutorScheduleEmptySlot themePrefix={themePrefix} />;
+  }
+
+  if (themePrefix === 'mySchedule' || themeConfig.emptySlotStyle === 'outlinedCard') {
+    return () => (
+      <OutlinedEmptySlot
+        themePrefix={themePrefix}
+        text={themeConfig.emptySlotText}
+        maxWidth={themeConfig.emptySlotMaxWidth}
+        minHeight={themeConfig.emptySlotMinHeight}
+        borderRadius={themeConfig.emptySlotBorderRadius}
+        borderStyle={themeConfig.emptySlotBorderStyle}
+      />
+    );
+  }
+
+  return () => <DefaultEmptySlot text={themeConfig.emptySlotText} />;
+}

--- a/packages/app/features/calendar/components/CalendarCardEmptySlots.tsx
+++ b/packages/app/features/calendar/components/CalendarCardEmptySlots.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Text, YStack } from 'tamagui';
 import type { CalendarThemeConfig } from '@mezon-tutors/shared';
 

--- a/packages/app/features/calendar/components/CalendarCardPresets.tsx
+++ b/packages/app/features/calendar/components/CalendarCardPresets.tsx
@@ -15,12 +15,16 @@ function MyLessonsPresetHeader({
   monthLabel,
   showMonthNav = true,
   isCompact,
+  onPrevWeek,
+  onNextWeek,
 }: {
   title: string;
   weekLabel: string;
   monthLabel: string;
   showMonthNav?: boolean;
   isCompact: boolean;
+  onPrevWeek?: () => void;
+  onNextWeek?: () => void;
 }) {
   return (
     <XStack
@@ -28,12 +32,16 @@ function MyLessonsPresetHeader({
       alignItems="center"
       gap="$3"
       flexWrap="wrap"
+      paddingTop="$3"
+      paddingBottom="$4"
     >
       <XStack
         alignItems="center"
         gap="$2.5"
       >
         <Text
+        
+          paddingLeft="$3"
           color="$myLessonsCalendarTitle"
           fontSize={isCompact ? 32 : 40}
           fontWeight="700"
@@ -50,12 +58,16 @@ function MyLessonsPresetHeader({
             <Text
               color="$myLessonsMonthNav"
               fontSize={18}
+              cursor={onPrevWeek ? 'pointer' : 'default'}
+              onPress={onPrevWeek}
             >
               {'<'}
             </Text>
             <Text
               color="$myLessonsMonthNav"
               fontSize={18}
+              cursor={onNextWeek ? 'pointer' : 'default'}
+              onPress={onNextWeek}
             >
               {'>'}
             </Text>
@@ -64,40 +76,19 @@ function MyLessonsPresetHeader({
       </XStack>
 
       <XStack
-        backgroundColor="$myLessonsSwitcherBackground"
-        borderWidth={1}
-        borderColor="$myLessonsSwitcherBorder"
+        backgroundColor="$myLessonsSwitcherActiveBackground"
         borderRadius={999}
-        padding={4}
-        gap={4}
+        paddingHorizontal="$3"
+        paddingVertical="$1.5"
+        marginRight="$3"
       >
-        <YStack
-          backgroundColor="$myLessonsSwitcherActiveBackground"
-          borderRadius={999}
-          paddingHorizontal="$3"
-          paddingVertical="$1.5"
+        <Text
+          color="$myLessonsSwitcherActiveText"
+          fontSize={12}
+          fontWeight="600"
         >
-          <Text
-            color="$myLessonsSwitcherActiveText"
-            fontSize={12}
-            fontWeight="600"
-          >
-            {weekLabel}
-          </Text>
-        </YStack>
-        <YStack
-          paddingHorizontal="$3"
-          paddingVertical="$1.5"
-          borderRadius={999}
-        >
-          <Text
-            color="$myLessonsSwitcherInactiveText"
-            fontSize={12}
-            fontWeight="600"
-          >
-            {monthLabel}
-          </Text>
-        </YStack>
+          {weekLabel}
+        </Text>
       </XStack>
     </XStack>
   );
@@ -122,6 +113,7 @@ function MyLessonsPresetFooter({
       >
         {legendItems.map((item) => (
           <XStack
+            paddingBottom="$2"
             key={item.key}
             alignItems="center"
             gap="$2"
@@ -334,6 +326,8 @@ const CALENDAR_CARD_PRESET_RENDERERS: Partial<
         monthLabel={data.monthLabel ?? 'Month'}
         showMonthNav={data.showMonthNav}
         isCompact={isCompact}
+        onPrevWeek={data.onPrevWeek}
+        onNextWeek={data.onNextWeek}
       />
     ) : undefined,
     footer: (

--- a/packages/app/features/calendar/components/CalendarCardPresets.tsx
+++ b/packages/app/features/calendar/components/CalendarCardPresets.tsx
@@ -1,0 +1,384 @@
+'use client';
+
+import { Button } from '@mezon-tutors/app/ui';
+import { Text, XStack, YStack } from 'tamagui';
+import type {
+  CalendarCardPresetRenderContext,
+  CalendarCardPresetRenderResult,
+  CalendarLegendItem,
+  CalendarType,
+} from '../types';
+
+function MyLessonsPresetHeader({
+  title,
+  weekLabel,
+  monthLabel,
+  showMonthNav = true,
+  isCompact,
+}: {
+  title: string;
+  weekLabel: string;
+  monthLabel: string;
+  showMonthNav?: boolean;
+  isCompact: boolean;
+}) {
+  return (
+    <XStack
+      justifyContent="space-between"
+      alignItems="center"
+      gap="$3"
+      flexWrap="wrap"
+    >
+      <XStack
+        alignItems="center"
+        gap="$2.5"
+      >
+        <Text
+          color="$myLessonsCalendarTitle"
+          fontSize={isCompact ? 32 : 40}
+          fontWeight="700"
+          lineHeight={isCompact ? 34 : 42}
+        >
+          {title}
+        </Text>
+
+        {showMonthNav && (
+          <XStack
+            alignItems="center"
+            gap="$2"
+          >
+            <Text
+              color="$myLessonsMonthNav"
+              fontSize={18}
+            >
+              {'<'}
+            </Text>
+            <Text
+              color="$myLessonsMonthNav"
+              fontSize={18}
+            >
+              {'>'}
+            </Text>
+          </XStack>
+        )}
+      </XStack>
+
+      <XStack
+        backgroundColor="$myLessonsSwitcherBackground"
+        borderWidth={1}
+        borderColor="$myLessonsSwitcherBorder"
+        borderRadius={999}
+        padding={4}
+        gap={4}
+      >
+        <YStack
+          backgroundColor="$myLessonsSwitcherActiveBackground"
+          borderRadius={999}
+          paddingHorizontal="$3"
+          paddingVertical="$1.5"
+        >
+          <Text
+            color="$myLessonsSwitcherActiveText"
+            fontSize={12}
+            fontWeight="600"
+          >
+            {weekLabel}
+          </Text>
+        </YStack>
+        <YStack
+          paddingHorizontal="$3"
+          paddingVertical="$1.5"
+          borderRadius={999}
+        >
+          <Text
+            color="$myLessonsSwitcherInactiveText"
+            fontSize={12}
+            fontWeight="600"
+          >
+            {monthLabel}
+          </Text>
+        </YStack>
+      </XStack>
+    </XStack>
+  );
+}
+
+function MyLessonsPresetFooter({
+  legendItems,
+  companyLabel,
+}: { legendItems: CalendarLegendItem[]; companyLabel?: string }) {
+  return (
+    <XStack
+      paddingTop="$2"
+      justifyContent="space-between"
+      alignItems="center"
+      flexWrap="wrap"
+      gap="$3"
+      paddingHorizontal="$1"
+    >
+      <XStack
+        gap="$3"
+        flexWrap="wrap"
+      >
+        {legendItems.map((item) => (
+          <XStack
+            key={item.key}
+            alignItems="center"
+            gap="$2"
+          >
+            <YStack
+              width={9}
+              height={9}
+              borderRadius={999}
+              backgroundColor={item.color}
+            />
+            <Text
+              color="$myLessonsLegendText"
+              fontSize={12}
+            >
+              {item.label}
+            </Text>
+          </XStack>
+        ))}
+      </XStack>
+
+      {companyLabel ? (
+        <Text
+          color="$myLessonsFooterText"
+          fontSize={12}
+        >
+          {companyLabel}
+        </Text>
+      ) : null}
+    </XStack>
+  );
+}
+
+function MySchedulePresetHeader({
+  title,
+  weekLabel,
+  monthLabel,
+}: {
+  title: string;
+  weekLabel: string;
+  monthLabel: string;
+}) {
+  return (
+    <XStack
+      justifyContent="space-between"
+      alignItems="center"
+      paddingHorizontal="$2"
+    >
+      <Text
+        fontSize={16}
+        fontWeight="700"
+        color="$myScheduleHeaderTitle"
+      >
+        {title}
+      </Text>
+      <XStack gap="$2">
+        <Button
+          size="$3"
+          variant="outlined"
+        >
+          {weekLabel}
+        </Button>
+        <Button
+          size="$3"
+          variant="outlined"
+        >
+          {monthLabel}
+        </Button>
+      </XStack>
+    </XStack>
+  );
+}
+
+function MySchedulePresetFooter({ legendItems }: { legendItems: CalendarLegendItem[] }) {
+  return (
+    <XStack
+      marginTop="$3"
+      gap="$3"
+      flexWrap="wrap"
+      paddingHorizontal="$1"
+    >
+      {legendItems.map((item) => (
+        <XStack
+          key={item.key}
+          alignItems="center"
+          gap="$2"
+        >
+          <YStack
+            width={9}
+            height={9}
+            borderRadius={999}
+            backgroundColor={item.color}
+          />
+          <Text
+            color="$myScheduleLegendText"
+            fontSize={12}
+          >
+            {item.label}
+          </Text>
+        </XStack>
+      ))}
+    </XStack>
+  );
+}
+
+function TutorSchedulePresetHeader({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <YStack gap="$3">
+      <Text
+        color="$tutorScheduleCalendarTitle"
+        fontSize={20}
+        fontWeight="800"
+      >
+        {title}
+      </Text>
+      {subtitle ? <Text color="$tutorScheduleCalendarSubtitle">{subtitle}</Text> : null}
+    </YStack>
+  );
+}
+
+function BookingPresetHeader({
+  title,
+  subtitle,
+  primaryDurationLabel,
+  secondaryDurationLabel,
+}: {
+  title: string;
+  subtitle?: string;
+  primaryDurationLabel?: string;
+  secondaryDurationLabel?: string;
+}) {
+  return (
+    <YStack gap="$3">
+      <XStack
+        justifyContent="space-between"
+        alignItems="center"
+        gap="$3"
+        flexWrap="wrap"
+      >
+        <Text
+          color="$myLessonsCalendarTitle"
+          fontSize={42}
+          fontWeight="700"
+          lineHeight={44}
+        >
+          {title}
+        </Text>
+        {primaryDurationLabel || secondaryDurationLabel ? (
+          <XStack
+            backgroundColor="$myLessonsSwitcherBackground"
+            borderWidth={1}
+            borderColor="$myLessonsSwitcherBorder"
+            borderRadius={999}
+            padding={4}
+            gap={4}
+          >
+            {primaryDurationLabel ? (
+              <YStack
+                backgroundColor="$myLessonsSwitcherActiveBackground"
+                borderRadius={999}
+                paddingHorizontal="$3"
+                paddingVertical="$1.5"
+              >
+                <Text
+                  color="$myLessonsSwitcherActiveText"
+                  fontSize={12}
+                  fontWeight="700"
+                >
+                  {primaryDurationLabel}
+                </Text>
+              </YStack>
+            ) : null}
+            {secondaryDurationLabel ? (
+              <YStack
+                paddingHorizontal="$3"
+                paddingVertical="$1.5"
+                borderRadius={999}
+              >
+                <Text
+                  color="$myLessonsSwitcherInactiveText"
+                  fontSize={12}
+                  fontWeight="700"
+                >
+                  {secondaryDurationLabel}
+                </Text>
+              </YStack>
+            ) : null}
+          </XStack>
+        ) : null}
+      </XStack>
+      {subtitle ? (
+        <Text
+          color="$myLessonsLegendText"
+          fontSize={14}
+        >
+          {subtitle}
+        </Text>
+      ) : null}
+    </YStack>
+  );
+}
+
+const CALENDAR_CARD_PRESET_RENDERERS: Partial<
+  Record<CalendarType, (context: CalendarCardPresetRenderContext) => CalendarCardPresetRenderResult>
+> = {
+  myLessons: ({ data, isCompact }) => ({
+    header: data.title ? (
+      <MyLessonsPresetHeader
+        title={data.title}
+        weekLabel={data.weekLabel ?? 'Week'}
+        monthLabel={data.monthLabel ?? 'Month'}
+        showMonthNav={data.showMonthNav}
+        isCompact={isCompact}
+      />
+    ) : undefined,
+    footer: (
+      <MyLessonsPresetFooter
+        legendItems={data.legendItems ?? []}
+        companyLabel={data.companyLabel}
+      />
+    ),
+  }),
+  mySchedule: ({ data }) => ({
+    header: data.title ? (
+      <MySchedulePresetHeader
+        title={data.title}
+        weekLabel={data.weekLabel ?? 'Week'}
+        monthLabel={data.monthLabel ?? 'Month'}
+      />
+    ) : undefined,
+    footer: data.legendItems?.length ? (
+      <MySchedulePresetFooter legendItems={data.legendItems} />
+    ) : undefined,
+  }),
+  tutorSchedule: ({ data }) => ({
+    header: data.title ? (
+      <TutorSchedulePresetHeader
+        title={data.title}
+        subtitle={data.subtitle}
+      />
+    ) : undefined,
+  }),
+  booking: ({ data }) => ({
+    header: data.title ? (
+      <BookingPresetHeader
+        title={data.title}
+        subtitle={data.subtitle}
+        primaryDurationLabel={data.primaryDurationLabel}
+        secondaryDurationLabel={data.secondaryDurationLabel}
+      />
+    ) : undefined,
+  }),
+};
+
+export function resolveCardPresetRender(
+  calendarType: CalendarType,
+  context: CalendarCardPresetRenderContext
+) {
+  const renderer = CALENDAR_CARD_PRESET_RENDERERS[calendarType];
+  return renderer ? renderer(context) : undefined;
+}

--- a/packages/app/features/calendar/components/CalendarCardPresets.tsx
+++ b/packages/app/features/calendar/components/CalendarCardPresets.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Button } from '@mezon-tutors/app/ui';
 import { Text, XStack, YStack } from 'tamagui';
 import type {

--- a/packages/app/features/calendar/components/CalendarColumn.tsx
+++ b/packages/app/features/calendar/components/CalendarColumn.tsx
@@ -1,0 +1,257 @@
+import { Text, XStack, YStack } from '@mezon-tutors/app/ui';
+import { useMemo } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import type { CalendarEvent, CalendarRowModel, CalendarSlotState } from '../types';
+import type { CalendarLayoutEngine } from './utils';
+
+export type CalendarColumnTokens = {
+  gridBorder: string;
+  currentColumn: string;
+  nowLine: string;
+  weekendLabel: string;
+};
+
+export type CalendarColumnConfig<TEvent> = {
+  layoutEngine: CalendarLayoutEngine;
+  rowHeight: number;
+  slotPadding: number;
+  eventPadding: number;
+  eventTopPadding: number;
+  readonly: boolean;
+  isCompact: boolean;
+  showNowLine?: boolean;
+  currentHour?: number;
+  headerHeight: number;
+  themeTokens: CalendarColumnTokens;
+  weekendNoSlotDays?: number[];
+  weekendNoSlotLabel?: string;
+  emptySlotMergeHours?: number;
+  onSlotClick?: (dayIndex: number, hour: number) => void;
+  renderEvent?: (event: CalendarEvent<TEvent>, isCompact: boolean) => ReactNode;
+  renderSlot?: (dayIndex: number, hour: number, state?: CalendarSlotState) => ReactNode;
+};
+
+type CalendarColumnProps<TEvent> = {
+  dayIndex: number;
+  events: CalendarEvent<TEvent>[];
+  rowModels: CalendarRowModel[];
+  isLast: boolean;
+  isActive: boolean;
+  showGridLines: boolean;
+  showTimelineGrid?: boolean;
+  config: CalendarColumnConfig<TEvent>;
+};
+
+type ColumnEmptySlotProps<TEvent> = {
+  row: Extract<CalendarRowModel, { type: 'hour' }>;
+  dayIndex: number;
+  config: CalendarColumnConfig<TEvent>;
+  height?: number;
+};
+
+function ColumnEmptySlot<TEvent>({ row, dayIndex, config, height }: ColumnEmptySlotProps<TEvent>) {
+  const top = config.layoutEngine.getY(row.hour);
+  const hasClick = !config.readonly && config.onSlotClick;
+
+  return (
+    <YStack
+      position="absolute"
+      top={top}
+      height={height ?? config.rowHeight}
+      width="100%"
+      cursor={hasClick ? 'pointer' : 'default'}
+      onPress={hasClick ? () => config.onSlotClick?.(dayIndex, row.hour) : undefined}
+      padding={config.slotPadding}
+    >
+      {config.renderSlot ? config.renderSlot(dayIndex, row.hour) : null}
+    </YStack>
+  );
+}
+
+type ColumnEventSlotProps<TEvent> = {
+  event: CalendarEvent<TEvent>;
+  config: CalendarColumnConfig<TEvent>;
+};
+
+function ColumnEventSlot<TEvent>({ event, config }: ColumnEventSlotProps<TEvent>) {
+  const top = config.layoutEngine.getY(event.startHour);
+  const endHour = event.endHour ?? event.startHour + 1;
+  const bottom = config.layoutEngine.getY(endHour);
+  const height = Math.max(0, bottom - top);
+  const inset = height > 8 ? 1 : 0;
+
+  return (
+    <YStack
+      position="absolute"
+      top={top + inset}
+      height={Math.max(0, height - inset * 2)}
+      width="100%"
+      paddingHorizontal={config.eventPadding}
+      paddingTop={config.eventTopPadding}
+      paddingBottom={config.eventPadding}
+      zIndex={10}
+    >
+      {config.renderEvent ? config.renderEvent(event, config.isCompact) : null}
+    </YStack>
+  );
+}
+
+function ColumnNowLine<TEvent>({ config }: { config: CalendarColumnConfig<TEvent> }) {
+  if (!config.showNowLine || config.currentHour === undefined) return null;
+
+  const top = config.layoutEngine.getY(config.currentHour);
+
+  return (
+    <XStack
+      position="absolute"
+      left={0}
+      right={0}
+      top={top}
+      alignItems="center"
+      pointerEvents="none"
+      zIndex={20}
+    >
+      <YStack
+        width={7}
+        height={7}
+        borderRadius={999}
+        backgroundColor={config.themeTokens.nowLine}
+        marginLeft={-4}
+      />
+      <YStack
+        flex={1}
+        height={2}
+        backgroundColor={config.themeTokens.nowLine}
+      />
+    </XStack>
+  );
+}
+
+function getEventEndHour(event: CalendarEvent<unknown>) {
+  return event.endHour ?? event.startHour + 1;
+}
+
+export function CalendarColumn<TEvent = unknown>({
+  dayIndex,
+  events,
+  rowModels,
+  isLast,
+  isActive,
+  showGridLines,
+  showTimelineGrid = true,
+  config,
+}: CalendarColumnProps<TEvent>) {
+  const isWeekendNoSlotsColumn =
+    events.length === 0 &&
+    Boolean(config.weekendNoSlotLabel) &&
+    Boolean(config.weekendNoSlotDays?.includes(dayIndex));
+  const mergeHours = Math.max(1, config.emptySlotMergeHours ?? 1);
+
+  const hourRows = useMemo(
+    () =>
+      rowModels.filter(
+        (row): row is Extract<CalendarRowModel, { type: 'hour' }> => row.type === 'hour'
+      ),
+    [rowModels]
+  );
+
+  const rowHourSet = useMemo(() => new Set(hourRows.map((row) => row.hour)), [hourRows]);
+
+  const occupiedHourSet = useMemo(() => {
+    if (!events.length) return new Set<number>();
+    const occupied = new Set<number>();
+    hourRows.forEach((row) => {
+      const hasOverlap = events.some(
+        (event) => event.startHour < row.hour + 1 && getEventEndHour(event) > row.hour
+      );
+      if (hasOverlap) occupied.add(row.hour);
+    });
+    return occupied;
+  }, [events, hourRows]);
+
+  const hasEventInHour = (hour: number) => occupiedHourSet.has(hour);
+
+  const weekendNoSlotLabelStyle: CSSProperties = {
+    letterSpacing: 1.2,
+    transform: 'rotate(90deg)',
+    whiteSpace: 'nowrap',
+  };
+
+  return (
+    <YStack
+      flex={1}
+      flexBasis={0}
+      minWidth={0}
+      borderRightWidth={showGridLines && !isLast ? 1 : 0}
+      borderRightColor={config.themeTokens.gridBorder}
+      borderTopWidth={showTimelineGrid ? 1 : 0}
+      borderTopColor={config.themeTokens.gridBorder}
+      backgroundColor={isActive ? config.themeTokens.currentColumn : 'transparent'}
+      position="relative"
+    >
+      {rowModels.map((row) => {
+        if (row.type === 'gap') return null;
+        if (isWeekendNoSlotsColumn) return null;
+        if (config.renderSlot && hasEventInHour(row.hour)) return null;
+
+        const isBlockStart =
+          !config.renderSlot || !hasEventInHour(row.hour - 1) || mergeHours === 1;
+
+        if (!isBlockStart) return null;
+
+        let span = 1;
+        if (config.renderSlot && mergeHours > 1) {
+          while (span < mergeHours) {
+            const nextHour = row.hour + span;
+            const hasNextHour = rowHourSet.has(nextHour);
+            if (!hasNextHour || hasEventInHour(nextHour)) break;
+            span += 1;
+          }
+        }
+
+        return (
+          <ColumnEmptySlot
+            key={`slot-${row.hour}`}
+            row={row}
+            dayIndex={dayIndex}
+            config={config}
+            height={config.rowHeight * span}
+          />
+        );
+      })}
+
+      {events.map((event) => (
+        <ColumnEventSlot
+          key={event.id}
+          event={event}
+          config={config}
+        />
+      ))}
+
+      {isWeekendNoSlotsColumn && (
+        <YStack
+          position="absolute"
+          left={0}
+          right={0}
+          top={config.headerHeight}
+          bottom={0}
+          alignItems="center"
+          justifyContent="center"
+          pointerEvents="none"
+        >
+          <Text
+            color={config.themeTokens.weekendLabel}
+            fontSize={11}
+            fontWeight="700"
+            opacity={0.45}
+            style={weekendNoSlotLabelStyle}
+          >
+            {config.weekendNoSlotLabel}
+          </Text>
+        </YStack>
+      )}
+
+      {isActive && <ColumnNowLine config={config} />}
+    </YStack>
+  );
+}

--- a/packages/app/features/calendar/components/CalendarDayHeader.tsx
+++ b/packages/app/features/calendar/components/CalendarDayHeader.tsx
@@ -1,0 +1,64 @@
+import { Text, YStack } from '@mezon-tutors/app/ui';
+import type { CalendarWeekDay } from '../types';
+
+export type CalendarDayHeaderTokens = {
+  gridBorder: string;
+  activeDayColumn: string;
+  dayLabel: string;
+  activeDate: string;
+  inactiveDate: string;
+};
+
+type CalendarDayHeaderProps = {
+  day: CalendarWeekDay;
+  dayIndex: number;
+  isActive: boolean;
+  isLast: boolean;
+  showGridLines: boolean;
+  tokens: CalendarDayHeaderTokens;
+};
+
+export function CalendarDayHeader({
+  day,
+  dayIndex,
+  isActive,
+  isLast,
+  showGridLines,
+  tokens,
+}: CalendarDayHeaderProps) {
+  return (
+    <YStack
+      flex={1}
+      flexBasis={0}
+      minWidth={0}
+      borderRightWidth={showGridLines && !isLast ? 1 : 0}
+      borderRightColor={tokens.gridBorder}
+      alignItems="center"
+      justifyContent="center"
+      gap={4}
+      paddingVertical={12}
+      backgroundColor={isActive ? tokens.activeDayColumn : 'transparent'}
+      borderRadius={isActive && !showGridLines ? 8 : 0}
+      borderWidth={isActive && !showGridLines ? 1 : 0}
+      borderColor={isActive && !showGridLines ? tokens.gridBorder : 'transparent'}
+    >
+      <Text
+        color={isActive ? tokens.activeDate : tokens.dayLabel}
+        fontSize={12}
+        textTransform="uppercase"
+        letterSpacing={1}
+        fontWeight="600"
+      >
+        {day.shortLabel}
+      </Text>
+      <Text
+        color={isActive ? tokens.activeDate : tokens.inactiveDate}
+        fontSize={18}
+        lineHeight={20}
+        fontWeight="700"
+      >
+        {day.dateLabel}
+      </Text>
+    </YStack>
+  );
+}

--- a/packages/app/features/calendar/components/CalendarGridLayer.tsx
+++ b/packages/app/features/calendar/components/CalendarGridLayer.tsx
@@ -1,0 +1,201 @@
+import { Text, XStack, YStack } from '@mezon-tutors/app/ui';
+import { useTranslations } from 'next-intl';
+import type { CalendarRowModel } from '../types';
+import type { CalendarLayoutEngine } from './utils';
+
+type CalendarGridLayerTokens = {
+  gridBorder: string;
+  gapCellBg: string;
+  gapLabel: string;
+  gapHint: string;
+  timeLabel: string;
+};
+
+export type CalendarGridLayerProps = {
+  rowModels: CalendarRowModel[];
+  layoutEngine: CalendarLayoutEngine;
+  showTimeline: boolean;
+  showGridLines: boolean;
+  showTimelineGrid?: boolean;
+  showDayColumnGridLines?: boolean;
+  timeColumnWidth: number;
+  rowHeight: number;
+  gapRowHeight: number;
+  formatHour: (hour: number) => string;
+  formatRangeLabel: (start: number, end: number) => string;
+  themeTokens: CalendarGridLayerTokens;
+  translationNamespace?: string;
+};
+
+type GridGapItemProps = {
+  row: Extract<CalendarRowModel, { type: 'gap' }>;
+  layoutEngine: CalendarLayoutEngine;
+  showTimeline: boolean;
+  showGridLines: boolean;
+  showTimelineGrid?: boolean;
+  showDayColumnGridLines?: boolean;
+  timeColumnWidth: number;
+  gapRowHeight: number;
+  formatRangeLabel: (start: number, end: number) => string;
+  themeTokens: CalendarGridLayerTokens;
+  translationNamespace?: string;
+};
+
+function GridGapItem({
+  row,
+  layoutEngine,
+  showTimeline,
+  showGridLines,
+  showTimelineGrid = true,
+  showDayColumnGridLines = true,
+  timeColumnWidth,
+  gapRowHeight,
+  formatRangeLabel,
+  themeTokens,
+  translationNamespace = 'MySchedule',
+}: GridGapItemProps) {
+  const t = useTranslations(translationNamespace);
+  const top = layoutEngine.getY(row.startHour);
+
+  return (
+    <>
+      {showDayColumnGridLines && (
+        <XStack
+          position="absolute"
+          top={top}
+          height={gapRowHeight}
+          width="100%"
+          backgroundColor={themeTokens.gapCellBg}
+          borderTopWidth={1}
+          borderTopColor={themeTokens.gridBorder}
+          pointerEvents="none"
+        />
+      )}
+      {showTimeline && (
+        <YStack
+          position="absolute"
+          top={top}
+          width={timeColumnWidth}
+          height={gapRowHeight}
+          borderRightWidth={showTimelineGrid ? 1 : 0}
+          borderRightColor={themeTokens.gridBorder}
+          borderTopWidth={showTimelineGrid ? 1 : 0}
+          borderTopColor={themeTokens.gridBorder}
+          backgroundColor={themeTokens.gapCellBg}
+          alignItems="center"
+          justifyContent="center"
+          paddingHorizontal={4}
+          gap={2}
+        >
+          <Text
+            color={themeTokens.gapLabel}
+            fontSize={10}
+            fontWeight="500"
+            textAlign="center"
+            numberOfLines={1}
+          >
+            {formatRangeLabel(row.startHour, row.endHour)}
+          </Text>
+          <Text
+            color={themeTokens.gapHint}
+            fontSize={9}
+            fontWeight="500"
+          >
+            {t('weekGrid.emptyHours', { hours: row.hourCount })}
+          </Text>
+        </YStack>
+      )}
+    </>
+  );
+}
+
+type GridHourItemProps = {
+  row: Extract<CalendarRowModel, { type: 'hour' }>;
+  layoutEngine: CalendarLayoutEngine;
+  showTimeline: boolean;
+  showGridLines: boolean;
+  showTimelineGrid?: boolean;
+  showDayColumnGridLines?: boolean;
+  timeColumnWidth: number;
+  rowHeight: number;
+  formatHour: (hour: number) => string;
+  themeTokens: CalendarGridLayerTokens;
+};
+
+function GridHourItem({
+  row,
+  layoutEngine,
+  showTimeline,
+  showGridLines,
+  showTimelineGrid = true,
+  showDayColumnGridLines = true,
+  timeColumnWidth,
+  rowHeight,
+  formatHour,
+  themeTokens,
+}: GridHourItemProps) {
+  const top = layoutEngine.getY(row.hour);
+
+  return (
+    <>
+      {showDayColumnGridLines && (
+        <XStack
+          position="absolute"
+          top={top}
+          height={rowHeight}
+          width="100%"
+          borderTopWidth={1}
+          borderTopColor={themeTokens.gridBorder}
+          pointerEvents="none"
+        />
+      )}
+      {showTimeline && (
+        <YStack
+          position="absolute"
+          top={top}
+          width={timeColumnWidth}
+          height={rowHeight}
+          borderRightWidth={showTimelineGrid ? 1 : 0}
+          borderRightColor={themeTokens.gridBorder}
+          borderTopWidth={showTimelineGrid ? 1 : 0}
+          borderTopColor={themeTokens.gridBorder}
+          alignItems="center"
+          paddingTop={10}
+        >
+          <Text
+            color={themeTokens.timeLabel}
+            fontSize={11}
+            fontWeight="500"
+          >
+            {formatHour(row.hour)}
+          </Text>
+        </YStack>
+      )}
+    </>
+  );
+}
+
+export function CalendarGridLayer(props: CalendarGridLayerProps) {
+  return (
+    <>
+      {props.rowModels.map((row) => {
+        if (row.type === 'gap') {
+          return (
+            <GridGapItem
+              key={`gap-${row.startHour}-${row.endHour}`}
+              row={row}
+              {...props}
+            />
+          );
+        }
+        return (
+          <GridHourItem
+            key={`hour-${row.hour}`}
+            row={row}
+            {...props}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/packages/app/features/calendar/components/utils.ts
+++ b/packages/app/features/calendar/components/utils.ts
@@ -1,0 +1,141 @@
+import type { CalendarRowModel } from '../types';
+
+export function buildRowModels(
+  weekHours: number[],
+  events: Array<{ dayIndex: number; startHour: number; endHour?: number }>,
+  currentHour: number | undefined,
+  enableGapCollapse: boolean,
+  minGapHours: number
+): CalendarRowModel[] {
+  if (!weekHours.length || !enableGapCollapse) {
+    return weekHours.map((hour) => ({ type: 'hour', hour }));
+  }
+
+  const sortedHours = [...weekHours].sort((a, b) => a - b);
+  const currentHourBucket = currentHour === undefined ? undefined : Math.floor(currentHour);
+
+  const occupiedHours = new Set<number>();
+  events.forEach((e) => {
+    const end = e.endHour ? Math.max(e.startHour + 1, e.endHour) : e.startHour + 1;
+    for (let h = Math.floor(e.startHour); h < end; h++) {
+      occupiedHours.add(h);
+    }
+  });
+
+  const rows: CalendarRowModel[] = [];
+  let index = 0;
+
+  while (index < sortedHours.length) {
+    const hour = sortedHours[index];
+    const isOccupied = occupiedHours.has(hour);
+    const isCurrentHour = hour === currentHourBucket;
+
+    if (isOccupied || isCurrentHour) {
+      rows.push({ type: 'hour', hour });
+      index += 1;
+      continue;
+    }
+
+    const startIndex = index;
+    while (index < sortedHours.length) {
+      const cursorHour = sortedHours[index];
+      if (occupiedHours.has(cursorHour) || cursorHour === currentHourBucket) {
+        break;
+      }
+      index += 1;
+    }
+
+    const emptyCount = index - startIndex;
+
+    if (emptyCount >= minGapHours) {
+      const startHour = sortedHours[startIndex];
+      const lastEmptyHour = sortedHours[index - 1] ?? startHour;
+      rows.push({
+        type: 'gap',
+        startHour,
+        endHour: Math.min(24, lastEmptyHour + 1),
+        hourCount: emptyCount,
+      });
+    } else {
+      for (let i = startIndex; i < index; i++) {
+        rows.push({ type: 'hour', hour: sortedHours[i] });
+      }
+    }
+  }
+
+  return rows;
+}
+
+export type CalendarLayoutConfig = {
+  rowHeight: number;
+  gapRowHeight: number;
+};
+
+export class CalendarLayoutEngine {
+  public totalHeight = 0;
+  private hourYs = new Map<number, number>();
+
+  constructor(
+    public rowModels: CalendarRowModel[],
+    public config: CalendarLayoutConfig
+  ) {
+    let currentY = 0;
+
+    this.rowModels.forEach((model) => {
+      if (model.type === 'hour') {
+        this.hourYs.set(model.hour, currentY);
+        currentY += config.rowHeight;
+      } else {
+        for (let h = model.startHour; h < model.endHour; h++) {
+          this.hourYs.set(h, currentY);
+        }
+        currentY += config.gapRowHeight;
+      }
+    });
+
+    this.totalHeight = currentY;
+  }
+
+  getY(hour: number): number {
+    const upperHour = Math.ceil(hour);
+    const lowerHour = Math.floor(hour);
+
+    const lowerY = this.hourYs.get(lowerHour) ?? this.extrapolateLowerOrUpper(lowerHour);
+
+    if (upperHour === lowerHour) {
+      return lowerY;
+    }
+
+    const upperY = this.hourYs.get(upperHour) ?? this.extrapolateLowerOrUpper(upperHour);
+    const fraction = hour - lowerHour;
+
+    return lowerY + (upperY - lowerY) * fraction;
+  }
+
+  private extrapolateLowerOrUpper(targetHour: number): number {
+    if (this.rowModels.length === 0) return 0;
+
+    let closestLowerHour = -1;
+    let closestLowerY = 0;
+
+    for (const [hour, y] of this.hourYs.entries()) {
+      if (hour <= targetHour && hour > closestLowerHour) {
+        closestLowerHour = hour;
+        closestLowerY = y;
+      }
+    }
+
+    if (closestLowerHour !== -1) {
+      return closestLowerY + (targetHour - closestLowerHour) * this.config.rowHeight;
+    }
+
+    const firstModel = this.rowModels[0];
+    const firstHour = firstModel.type === 'hour' ? firstModel.hour : firstModel.startHour;
+
+    if (targetHour < firstHour) {
+      return (targetHour - firstHour) * this.config.rowHeight;
+    }
+
+    return 0;
+  }
+}

--- a/packages/app/features/calendar/index.ts
+++ b/packages/app/features/calendar/index.ts
@@ -1,5 +1,6 @@
 export { Calendar } from './components/Calendar';
 export { CalendarCard } from './components/CalendarCard';
+export { formatCalendarTitle, formatWeekDays } from './utils/format-locale';
 export type {
   BaseCalendarProps,
   CalendarCardPresetRenderContext,

--- a/packages/app/features/calendar/index.ts
+++ b/packages/app/features/calendar/index.ts
@@ -1,0 +1,16 @@
+export { Calendar } from './components/Calendar';
+export { CalendarCard } from './components/CalendarCard';
+export type {
+  BaseCalendarProps,
+  CalendarCardPresetRenderContext,
+  CalendarCardPresetRenderResult,
+  CalendarType,
+  CalendarEvent,
+  CalendarLegendItem,
+  CalendarPresetData,
+  CalendarRowModel,
+  CalendarSlotState,
+  CalendarTimeSlot,
+  CalendarViewMode,
+  CalendarWeekDay,
+} from './types';

--- a/packages/app/features/calendar/types.ts
+++ b/packages/app/features/calendar/types.ts
@@ -44,6 +44,8 @@ export type CalendarPresetData = {
   companyLabel?: string;
   primaryDurationLabel?: string;
   secondaryDurationLabel?: string;
+  onPrevWeek?: () => void;
+  onNextWeek?: () => void;
 };
 
 export type CalendarCardPresetRenderContext = {

--- a/packages/app/features/calendar/types.ts
+++ b/packages/app/features/calendar/types.ts
@@ -1,0 +1,79 @@
+import type { ReactNode } from 'react';
+
+export type CalendarViewMode = 'week' | 'month' | 'day';
+
+export type CalendarType = 'calendar' | 'myLessons' | 'mySchedule' | 'tutorSchedule' | 'booking';
+
+export type CalendarSlotState = 'available' | 'selected' | 'occupied' | 'blocked' | 'pending';
+
+export type CalendarWeekDay = {
+  shortLabel: string;
+  dateLabel: string;
+  fullDate?: Date;
+};
+
+export type CalendarTimeSlot = {
+  hour: number;
+  dayIndex: number;
+  state?: CalendarSlotState;
+  data?: unknown;
+};
+
+export type CalendarEvent<T = unknown> = {
+  id: string;
+  dayIndex: number;
+  startHour: number;
+  endHour?: number;
+  data: T;
+};
+
+export type CalendarLegendItem = {
+  key: string;
+  label: string;
+  color: string;
+};
+
+export type CalendarPresetData = {
+  title?: string;
+  subtitle?: string;
+  weekLabel?: string;
+  monthLabel?: string;
+  showMonthNav?: boolean;
+  showViewSwitcher?: boolean;
+  legendItems?: CalendarLegendItem[];
+  companyLabel?: string;
+  primaryDurationLabel?: string;
+  secondaryDurationLabel?: string;
+};
+
+export type CalendarCardPresetRenderContext = {
+  data: CalendarPresetData;
+  isCompact: boolean;
+};
+
+export type CalendarCardPresetRenderResult = {
+  header?: ReactNode;
+  footer?: ReactNode;
+};
+
+export type CalendarRowModel =
+  | { type: 'hour'; hour: number }
+  | { type: 'gap'; startHour: number; endHour: number; hourCount: number };
+
+export type BaseCalendarProps<TEvent = unknown> = {
+  viewMode?: CalendarViewMode;
+  type?: CalendarType;
+  weekDays: CalendarWeekDay[];
+  weekHours: number[];
+  events?: CalendarEvent<TEvent>[];
+  currentDayIndex?: number;
+  currentHour?: number;
+  enableGapCollapse?: boolean;
+  minGapHours?: number;
+  readonly?: boolean;
+  onSlotClick?: (dayIndex: number, hour: number) => void;
+  renderEvent?: (event: CalendarEvent<TEvent>, isCompact: boolean) => ReactNode;
+  renderSlot?: (dayIndex: number, hour: number, state?: CalendarSlotState) => ReactNode;
+  themePrefix?: string;
+  isCompact?: boolean;
+};

--- a/packages/app/features/calendar/utils/format-locale.ts
+++ b/packages/app/features/calendar/utils/format-locale.ts
@@ -1,0 +1,19 @@
+import dayjs from 'dayjs';
+import 'dayjs/locale/vi';
+import 'dayjs/locale/en';
+import type { CalendarWeekDay } from '../types';
+
+export function formatCalendarTitle(title: string, locale: string): string {
+  const date = dayjs.utc(title, 'MMMM YYYY', true).locale(locale);
+  return date.isValid() ? date.format('MMMM YYYY') : title;
+}
+
+export function formatWeekDays(weekDays: CalendarWeekDay[], locale: string): CalendarWeekDay[] {
+  return weekDays.map((day) => {
+    const dayDate = dayjs.utc(`2026-04-${day.dateLabel}`, 'YYYY-MM-DD').locale(locale);
+    return {
+      shortLabel: dayDate.format('ddd').toUpperCase(),
+      dateLabel: day.dateLabel,
+    };
+  });
+}

--- a/packages/app/features/calendar/utils/format-locale.ts
+++ b/packages/app/features/calendar/utils/format-locale.ts
@@ -9,8 +9,19 @@ export function formatCalendarTitle(title: string, locale: string): string {
 }
 
 export function formatWeekDays(weekDays: CalendarWeekDay[], locale: string): CalendarWeekDay[] {
-  return weekDays.map((day) => {
-    const dayDate = dayjs.utc(`2026-04-${day.dateLabel}`, 'YYYY-MM-DD').locale(locale);
+  return weekDays.map((day, index) => {
+    let dayDate: dayjs.Dayjs;
+    
+    if (day.fullDate) {
+      dayDate = dayjs(day.fullDate).locale(locale);
+    } else {
+      const now = dayjs();
+      const dayOfWeek = now.day();
+      const mondayOffset = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+      const monday = now.subtract(mondayOffset, 'day');
+      dayDate = monday.add(index, 'day').locale(locale);
+    }
+    
     return {
       shortLabel: dayDate.format('ddd').toUpperCase(),
       dateLabel: day.dateLabel,

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -16,3 +16,5 @@ export * from './features/tutors/detail.screen';
 
 export * from './features/admin/tutor-applications/screen';
 export * from './provider';
+
+export * from './features/calendar';

--- a/packages/shared/src/constants/calendar.ts
+++ b/packages/shared/src/constants/calendar.ts
@@ -1,0 +1,215 @@
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export const CALENDAR_CONFIG = {
+  MIN_GAP_HOURS: 2,
+  TIME_COLUMN_WIDTH: {
+    COMPACT: 66,
+    NORMAL: 78,
+  },
+  ROW_HEIGHT: {
+    COMPACT: 78,
+    NORMAL: 88,
+  },
+  GAP_ROW_HEIGHT: {
+    COMPACT: 52,
+    NORMAL: 60,
+  },
+  HEADER_HEIGHT: 72,
+  EVENT_WIDTH: {
+    COMPACT: 122,
+    NORMAL: 136,
+  },
+  DAYS_PER_WEEK: 7,
+} as const;
+
+export type CalendarThemeConfig = {
+  showTimeline: boolean;
+  showGridLines: boolean;
+  showTimelineGrid?: boolean;
+  showDayColumnGridLines?: boolean;
+  showGridOuterBorder?: boolean; 
+  showNowLine: boolean;
+  cardBorder?: boolean;
+  cardBorderRadius?: number;
+  cardPadding?: number;
+  rowHeight?: number;
+  gapRowHeight?: number;
+  eventMaxWidth?: number;
+  eventMaxHeight?: number;
+  eventBorderRadius?: number;
+  eventPadding?: number;
+  eventTopPadding?: number;
+  showEmptySlots?: boolean;
+  emptySlotText?: string;
+  emptySlotStyle?: 'text' | 'outlinedCard';
+  emptySlotBorderStyle?: 'solid' | 'dashed';
+  emptySlotMaxWidth?: number;
+  emptySlotMinHeight?: number;
+  emptySlotBorderRadius?: number;
+  emptySlotMergeHours?: number;
+  weekendNoSlotDays?: number[];
+  weekendNoSlotLabel?: string;
+  translationNamespace?: string;
+};
+
+export const DEFAULT_THEME_CONFIG: CalendarThemeConfig = {
+  showTimeline: true,
+  showGridLines: true,
+  showNowLine: false,
+  cardBorder: true,
+  cardBorderRadius: 16,
+  cardPadding: 16,
+  eventMaxWidth: undefined,
+  eventMaxHeight: undefined,
+  eventBorderRadius: 12,
+  eventPadding: 8,
+  eventTopPadding: undefined,
+  showEmptySlots: false,
+  emptySlotText: undefined,
+  emptySlotStyle: 'text',
+  emptySlotBorderStyle: 'solid',
+  emptySlotMaxWidth: undefined,
+  emptySlotMinHeight: undefined,
+  emptySlotBorderRadius: 12,
+  emptySlotMergeHours: 1,
+  weekendNoSlotDays: [],
+  weekendNoSlotLabel: undefined,
+  translationNamespace: 'MySchedule',
+};
+
+export const CALENDAR_THEME_CONFIG: Record<string, CalendarThemeConfig> = {
+  myLessons: {
+    showTimeline: true,
+    showGridLines: true,
+    showGridOuterBorder: true,
+    showNowLine: true,
+    cardBorder: false,
+    cardBorderRadius: 0,
+    cardPadding: 0,
+    eventMaxWidth: 136,
+    eventMaxHeight: undefined,
+    eventBorderRadius: 12,
+    eventPadding: 8,
+    eventTopPadding: 0,
+    showEmptySlots: false,
+    translationNamespace: 'MyLessons',
+  },
+  tutorSchedule: {
+    showTimeline: true,
+    showGridLines: false,
+    showGridOuterBorder: true,
+    showNowLine: false,
+    cardBorder: false,
+    cardBorderRadius: 0,
+    cardPadding: 0,
+    eventMaxWidth: 120,
+    eventMaxHeight: 68,
+    eventBorderRadius: 12,
+    eventPadding: 8,
+    eventTopPadding: 8,
+    showEmptySlots: true,
+    emptySlotText: undefined,
+    emptySlotStyle: 'outlinedCard',
+    emptySlotBorderStyle: 'solid',
+    emptySlotMaxWidth: 110,
+    emptySlotMinHeight: 56,
+    emptySlotBorderRadius: 12,
+    emptySlotMergeHours: 1,
+    translationNamespace: 'MySchedule',
+  },
+  mySchedule: {
+    showTimeline: true,
+    showGridLines: true,
+    showTimelineGrid: true,
+    showDayColumnGridLines: false,
+    showGridOuterBorder: true,
+    showNowLine: false,
+    cardBorder: true,
+    cardBorderRadius: 16,
+    cardPadding: 16,
+    eventBorderRadius: 12,
+    eventTopPadding: 8,
+    rowHeight: 100,
+    gapRowHeight: 68,
+    showEmptySlots: false,
+    translationNamespace: 'MySchedule',
+  },
+  booking: {
+    showTimeline: true,
+    showGridLines: true,
+    showNowLine: false,
+    cardBorder: true,
+    cardBorderRadius: 16,
+    cardPadding: 16,
+    eventBorderRadius: 12,
+    eventTopPadding: 8,
+    showEmptySlots: false,
+    translationNamespace: 'MySchedule',
+  },
+};
+
+export function getFallbackWeekHours(): number[] {
+  const currentHour = dayjs().hour();
+  const startHour = Math.max(0, currentHour - 2);
+  const endHour = Math.min(23, startHour + 4);
+
+  return Array.from({ length: endHour - startHour + 1 }, (_, index) => startHour + index);
+}
+
+export function buildFallbackWeekDays() {
+  const now = dayjs();
+  const dayOfWeek = now.day();
+  const mondayOffset = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+  const monday = now.subtract(mondayOffset, 'day');
+
+  return Array.from({ length: 7 }, (_, index) => {
+    const date = monday.add(index, 'day');
+
+    return {
+      shortLabel: date.format('ddd'),
+      dateLabel: date.format('DD'),
+    };
+  });
+}
+
+export function calculateDynamicTimelineHours(
+  events: Array<{ startsAt: Date | string; endsAt: Date | string }>,
+  availabilitySlots?: Array<{ startTime: string; endTime: string }>
+): number[] {
+  const hours = new Set<number>();
+
+  events.forEach((event) => {
+    const startHour = dayjs(event.startsAt).tz('Asia/Ho_Chi_Minh').hour();
+    const endHour = dayjs(event.endsAt).tz('Asia/Ho_Chi_Minh').hour();
+    
+    for (let h = startHour; h <= endHour; h++) {
+      hours.add(h);
+    }
+  });
+
+  if (availabilitySlots) {
+    availabilitySlots.forEach((slot) => {
+      const [startHour] = slot.startTime.split(':').map(Number);
+      const [endHour] = slot.endTime.split(':').map(Number);
+      
+      for (let h = startHour; h <= endHour; h++) {
+        hours.add(h);
+      }
+    });
+  }
+
+  if (hours.size === 0) {
+    return [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21];
+  }
+
+  const sortedHours = Array.from(hours).sort((a, b) => a - b);
+  const minHour = sortedHours[0];
+  const maxHour = sortedHours[sortedHours.length - 1];
+
+  return Array.from({ length: maxHour - minHour + 1 }, (_, i) => minHour + i);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,6 +26,8 @@ export * from './constants/footer';
 export * from './constants/header';
 export * from './constants/dashboard';
 export * from './constants/dashboard-booking-request';
+export * from './constants/calendar';
+export * from './constants/my-schedule';
 
 // Utils
 export * from './utils/utils';


### PR DESCRIPTION
# Add reusable Calendar component

Shared Calendar component for My Lessons, Tutor Schedule, My Schedule, and Booking.

## Features

- **Reusable** - Single component, multiple themes via `type` prop
- **Gap collapse** - Auto-collapse empty slots (≥2 hours)
- **Type-safe** - Generic `Calendar<TEvent>`
- **Responsive** - Auto-detect compact/normal mode
- **i18n ready** - Multi-language support (en, vi)
- **Customizable** - `renderEvent` and `renderSlot` props

## Architecture

- 2-layer system: Grid layer + Columns layer
- 8 files: 7 components + 1 utils
- Exported from `@mezon-tutors/app`

## Screenshots

### My Lessons
<img width="1187" alt="My Lessons" src="https://github.com/user-attachments/assets/3da8ea3c-03c3-4298-8132-c0393f33d515" />

### Tutor Schedule
<img width="1187" height="472" alt="image" src="https://github.com/user-attachments/assets/ab7aca71-d68f-4007-996c-a78ecab65693" />

### My Schedule
<img width="1916" alt="My Schedule" src="https://github.com/user-attachments/assets/98a3abab-428b-4eb8-93e5-0d1f3408e7a0" />
