### PR TITLE
Fix/refactor and responsive for Dashboard, My Lesson Calendar on mobile

### DIFF
--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,154 +1,84 @@
-'use client'
+'use client';
 
-import type { ReactNode } from 'react'
-import { useEffect } from 'react'
-import { useTranslations } from 'next-intl'
-import { usePathname, useRouter } from 'next/navigation'
-import { useAtomValue, useSetAtom } from 'jotai'
-import Link from 'next/link'
-import { Screen, XStack, YStack, Text, Button } from '@mezon-tutors/app/ui'
-import { type DashboardMenuIconKey, type DashboardMenuItem, DASHBOARD_MENU_ITEMS } from '@mezon-tutors/shared/src/constants/dashboard'
-import { ROUTES } from '@mezon-tutors/shared/src/constants/routes'
-import { isLoadingAtom, logoutAtom, userAtom } from '@mezon-tutors/app/store/auth.atom'
-import { BookingRequestIcon, CalendarIcon, DocumentIcon, LogoutIcon } from '@mezon-tutors/app/ui/icons'
-import { useThemeName } from 'tamagui'
-import { themes } from '@mezon-tutors/app/theme/theme'
-
-type AppTheme = (typeof themes)[keyof typeof themes]
-
-const DASHBOARD_ICON_COMPONENTS: Record<
-  DashboardMenuIconKey,
-  React.ComponentType<{ size?: number; color?: string }>
-> = {
-  document: DocumentIcon,
-  bookingRequests: BookingRequestIcon,
-  calendar: CalendarIcon,
-  logout: LogoutIcon,
-}
-
-function getDashboardMenuDisplay(
-  item: DashboardMenuItem,
-  pathname: string,
-  dashboardTheme: AppTheme
-) {
-  const active = item.type === 'link' && !!item.href && pathname === item.href
-  const isLogoutItem = item.type === 'action'
-
-  return {
-    active,
-    Icon: DASHBOARD_ICON_COMPONENTS[item.iconKey],
-    iconColor: isLogoutItem
-      ? dashboardTheme.myLessonsSidebarLogoutIcon
-      : active
-        ? dashboardTheme.dashboardTutorFilterActiveBg
-        : dashboardTheme.dashboardTutorTextSecondary,
-    labelColor: isLogoutItem
-      ? '$myLessonsSidebarLogoutText'
-      : active
-        ? '$dashboardTutorFilterActiveBg'
-        : '$dashboardTutorTextSecondary',
-  }
-}
+import type { ReactNode } from 'react';
+import { useEffect, useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import { usePathname, useRouter } from 'next/navigation';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { Screen, XStack, YStack } from '@mezon-tutors/app/ui';
+import { getDashboardMenuItemsByRole } from '@mezon-tutors/shared/src/constants/dashboard';
+import { ROUTES } from '@mezon-tutors/shared/src/constants/routes';
+import { isLoadingAtom, logoutAtom, userAtom } from '@mezon-tutors/app/store/auth.atom';
+import { useThemeName, useMedia } from 'tamagui';
+import { themes } from '@mezon-tutors/app/theme/theme';
+import { DashboardSidebar } from '@mezon-tutors/app/features/dashboard/sidebar/DashboardSidebar';
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
-  const pathname = usePathname()
-  const router = useRouter()
-  const themeName = useThemeName()
-  const t = useTranslations('Dashboard')
-  const user = useAtomValue(userAtom)
-  const isAuthLoading = useAtomValue(isLoadingAtom)
-  const logout = useSetAtom(logoutAtom)
-  const dashboardTheme = themeName === 'dark' ? themes.dark : themes.light
-  const role = user?.role === 'STUDENT' ? 'STUDENT' : 'TUTOR'
-  const visibleMenuItems = DASHBOARD_MENU_ITEMS.filter((item) => item.roles.includes(role))
+  const pathname = usePathname();
+  const router = useRouter();
+  const themeName = useThemeName();
+  const media = useMedia();
+  const isMobile = media.sm || media.xs;
+  const t = useTranslations('Dashboard');
+  const user = useAtomValue(userAtom);
+  const isAuthLoading = useAtomValue(isLoadingAtom);
+  const logout = useSetAtom(logoutAtom);
+  const dashboardTheme = themeName === 'dark' ? themes.dark : themes.light;
+  const visibleMenuItems = useMemo(() => getDashboardMenuItemsByRole(user?.role), [user?.role]);
 
   useEffect(() => {
     if (isAuthLoading) {
-      return
+      return;
     }
 
     if (!user?.role) {
-      router.replace(ROUTES.HOME.index)
+      router.replace(ROUTES.HOME.index);
     }
-  }, [isAuthLoading, router, user?.role])
+  }, [isAuthLoading, router, user?.role]);
 
   if (isAuthLoading) {
-    return null
+    return null;
   }
 
   if (!user?.role) {
-    return null
+    return null;
   }
 
   const handleLogout = async () => {
-    await logout()
-    router.push(ROUTES.HOME.index)
-  }
+    await logout();
+    router.push(ROUTES.HOME.index);
+  };
 
   return (
     <Screen>
-      <XStack minHeight="100vh" flexDirection="row" flexWrap="nowrap">
+      <XStack
+        minHeight="100vh"
+        flexDirection="row"
+        flexWrap="nowrap"
+        position="relative"
+      >
+        {!isMobile && (
+          <DashboardSidebar
+            items={visibleMenuItems}
+            pathname={pathname}
+            activeIconColor={dashboardTheme.dashboardTutorFilterActiveBg || '#3B82F6'}
+            inactiveIconColor={dashboardTheme.dashboardTutorTextSecondary || '#6B7280'}
+            logoutIconColor={dashboardTheme.myLessonsSidebarLogoutIcon || '#EF4444'}
+            onLogout={handleLogout}
+            t={t}
+          />
+        )}
+
         <YStack
-          width={240}
-          minWidth={240}
-          backgroundColor="$dashboardTutorSidebarBackground"
-          borderRightWidth={1}
-          borderRightColor="$dashboardTutorSidebarBorder"
-          padding="$4"
-          gap="$3"
+          flex={1}
+          minWidth={0}
+          backgroundColor="$dashboardTutorPageBackground"
+          padding={isMobile ? 12 : '$4'}
+          paddingTop={isMobile ? 12 : '$4'}
         >
-          {visibleMenuItems.map((item: DashboardMenuItem) => {
-            const { active, Icon: ItemIcon, iconColor, labelColor } = getDashboardMenuDisplay(
-              item,
-              pathname,
-              dashboardTheme
-            )
-
-            const content = (
-              <Button
-                onPress={item.type === 'action' ? handleLogout : undefined}
-                borderWidth={active ? 1 : 0}
-                borderColor="$dashboardTutorSidebarItemActiveBorder"
-                backgroundColor={active ? '$dashboardTutorSidebarItemActiveBg' : 'transparent'}
-                color={labelColor}
-                paddingVertical="$2"
-                paddingHorizontal="$3"
-                borderRadius={12}
-                flexDirection="row"
-                alignItems="center"
-                gap="$2"
-                justifyContent="flex-start"
-                style={{ cursor: 'pointer' }}
-                hoverStyle={{
-                  backgroundColor: '$dashboardTutorSidebarItemHover',
-                  borderColor: '$dashboardTutorSidebarItemActiveBorder',
-                }}
-              >
-                <ItemIcon size={item.iconKey === 'bookingRequests' ? 19 : 16} color={iconColor} />
-                <Text color={labelColor} fontWeight={active ? '700' : '500'}>
-                  {t(`sidebar.${item.labelKey}`)}
-                </Text>
-              </Button>
-            )
-
-            if (item.type === 'link' && item.href) {
-              return (
-                <Link key={item.key} href={item.href} style={{ textDecoration: 'none' }}>
-                  {content}
-                </Link>
-              )
-            }
-
-            return <YStack key={item.key}>{content}</YStack>
-          })}
-
-          <YStack marginTop="auto" width="100%" />
-        </YStack>
-
-        <YStack flex={1} minWidth={0} backgroundColor="$dashboardTutorPageBackground" padding="$4">
           {children}
         </YStack>
       </XStack>
     </Screen>
-  )
+  );
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -504,3 +504,87 @@ body {
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
+
+@media (max-width: 660px) {
+  .mobile-avatar {
+    width: 28px !important;
+    height: 28px !important;
+  }
+}
+
+@media (min-width: 661px) and (max-width: 900px) {
+  .mobile-avatar {
+    width: 32px !important;
+    height: 32px !important;
+  }
+}
+
+@media (max-width: 340px) {
+  .mobile-calendar-container {
+    gap: 8px !important;
+    padding-left: 2px !important;
+    padding-right: 2px !important;
+  }
+  
+  .week-days-container {
+    gap: 1px !important;
+    justify-content: space-between !important;
+    padding-left: 0px !important;
+    padding-right: 0px !important;
+  }
+  
+  .week-day-button {
+    min-width: 40px !important;
+    max-width: 40px !important;
+    width: 40px !important;
+    padding-left: 0px !important;
+    padding-right: 0px !important;
+    border-radius: 7px !important;
+    flex-shrink: 0 !important;
+  }
+  
+  .week-day-label {
+    font-size: 6.5px !important;
+    letter-spacing: -0.5px !important;
+    line-height: 8px !important;
+  }
+  
+  .week-day-date {
+    font-size: 12px !important;
+    line-height: 15px !important;
+    font-weight: 700 !important;
+  }
+  
+  .month-title {
+    font-size: 11px !important;
+  }
+  
+  .mobile-header-logo {
+    padding: 6px !important;
+    gap: 0 !important;
+  }
+  
+  .my-lessons-title-mobile {
+    font-size: 24px !important;
+    line-height: 30px !important;
+  }
+  
+  .my-lessons-button-mobile {
+    font-size: 13px !important;
+    padding: 8px 12px !important;
+  }
+  
+  .my-lessons-screen-container {
+    padding-left: 2px !important;
+    padding-right: 2px !important;
+  }
+}
+
+.mobile-header-logo:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.2);
+}
+
+.mobile-header-logo:active {
+  transform: scale(0.95);
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { NextIntlClientProvider } from 'next-intl';
 import './globals.css';
@@ -26,6 +26,15 @@ export const metadata: Metadata = {
   title: 'Mezon Learning | Find Your Best Language Tutor',
   description:
     'Learn faster with your best language tutor. Book experienced tutors for 120+ subjects.',
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  minimumScale: 1,
+  maximumScale: 5,
+  userScalable: true,
+  viewportFit: 'cover',
 };
 
 export default async function RootLayout({

--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -1,144 +1,303 @@
-'use client'
-import Link from 'next/link'
-import { useAtomValue } from 'jotai'
-import { isAuthenticatedAtom, userAtom } from '@mezon-tutors/app/store/auth.atom'
-import { LoginButton } from '@mezon-tutors/app/components/auth/LoginButton'
-import { HEADER_NAV, ROUTES } from '@mezon-tutors/shared'
-import { useCallback } from 'react'
-import { useLocale, useTranslations } from 'next-intl'
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { XStack, Text, Button } from '@mezon-tutors/app/ui'
-import { LogoIcon } from '@mezon-tutors/app/ui/icons'
-import { themes } from '@mezon-tutors/app/theme/theme'
-import { useThemeName } from 'tamagui'
-import { HeaderLocaleToggle } from './HeaderLocaleToggle'
-import { HeaderThemeToggle } from './HeaderThemeToggle'
-import { HeaderNavLink } from './HeaderNavLink'
+'use client';
+import Link from 'next/link';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { isAuthenticatedAtom, userAtom, logoutAtom } from '@mezon-tutors/app/store/auth.atom';
+import { LoginButton } from '@mezon-tutors/app/components/auth/LoginButton';
+import { HEADER_NAV, ROUTES, HEADER_CONFIG } from '@mezon-tutors/shared';
+import { getDashboardMenuItemsByRole } from '@mezon-tutors/shared/src/constants/dashboard';
+import { useCallback, useMemo, useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { XStack, Text, Button } from '@mezon-tutors/app/ui';
+import { LogoIcon, MenuIcon } from '@mezon-tutors/app/ui/icons';
+import { themes } from '@mezon-tutors/app/theme/theme';
+import { useThemeName, useMedia } from 'tamagui';
+import { HeaderLocaleToggle } from './HeaderLocaleToggle';
+import { HeaderThemeToggle } from './HeaderThemeToggle';
+import { HeaderNavLink } from './HeaderNavLink';
+import { DashboardMobileDrawer } from '@mezon-tutors/app/features/dashboard/mobile-drawer/DashboardMobileDrawer';
 
 export default function Header() {
-  const locale = useLocale()
-  const t = useTranslations('Common.Header')
-  const router = useRouter()
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
-  const themeName = useThemeName()
-  const isAuthenticated = useAtomValue(isAuthenticatedAtom)
-  const user = useAtomValue(userAtom)
-  const themeMode: 'light' | 'dark' = themeName === 'dark' ? 'dark' : 'light'
-  const headerTheme = themeMode === 'dark' ? themes.dark : themes.light
+  const locale = useLocale();
+  const t = useTranslations('Common.Header');
+  const tDashboard = useTranslations('Dashboard');
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const themeName = useThemeName();
+  const media = useMedia();
+  const isMobile = media.sm || media.xs;
+  const isAuthenticated = useAtomValue(isAuthenticatedAtom);
+  const user = useAtomValue(userAtom);
+  const logout = useSetAtom(logoutAtom);
+  const themeMode: 'light' | 'dark' = themeName === 'dark' ? 'dark' : 'light';
+  const headerTheme = themeMode === 'dark' ? themes.dark : themes.light;
+  const dashboardTheme = themeName === 'dark' ? themes.dark : themes.light;
+
+  const isDashboard = pathname.startsWith('/dashboard');
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  const visibleMenuItems = useMemo(() => getDashboardMenuItemsByRole(user?.role), [user?.role]);
 
   const toggleTheme = useCallback(() => {
-    const nextTheme = themeMode === 'dark' ? 'light' : 'dark'
-    window.dispatchEvent(new CustomEvent('app-theme-change', { detail: nextTheme }))
-  }, [themeMode])
+    const nextTheme = themeMode === 'dark' ? 'light' : 'dark';
+    window.dispatchEvent(new CustomEvent('app-theme-change', { detail: nextTheme }));
+  }, [themeMode]);
 
   const switchLocale = useCallback(
     (nextLocale: 'en' | 'vi') => {
-      if (nextLocale === locale) return
+      if (nextLocale === locale) return;
 
-      const isHttps = window.location.protocol === 'https:'
-      document.cookie = `NEXT_LOCALE=${nextLocale}; path=/; max-age=31536000; samesite=lax${isHttps ? '; secure' : ''}`
+      const isHttps = window.location.protocol === 'https:';
+      document.cookie = `NEXT_LOCALE=${nextLocale}; path=/; max-age=31536000; samesite=lax${isHttps ? '; secure' : ''}`;
 
-      const query = searchParams.toString()
-      const nextPath = query ? `${pathname}?${query}` : pathname
-      router.replace(nextPath)
-      router.refresh()
+      const query = searchParams.toString();
+      const nextPath = query ? `${pathname}?${query}` : pathname;
+      router.replace(nextPath);
+      router.refresh();
     },
     [locale, pathname, router, searchParams]
-  )
+  );
 
   const toggleLocale = useCallback(() => {
-    const nextLocale = locale === 'en' ? 'vi' : 'en'
-    void switchLocale(nextLocale)
-  }, [locale, switchLocale])
+    const nextLocale = locale === 'en' ? 'vi' : 'en';
+    void switchLocale(nextLocale);
+  }, [locale, switchLocale]);
 
   const goToDashboard = useCallback(() => {
-    router.push(ROUTES.DASHBOARD.INDEX)
-  }, [router])
+    router.push(ROUTES.DASHBOARD.INDEX);
+  }, [router]);
+
+  const handleMenuPress = useCallback(() => {
+    setIsSidebarOpen(true);
+  }, []);
+
+  const handleCloseSidebar = useCallback(() => {
+    setIsSidebarOpen(false);
+  }, []);
+
+  const handleLogout = useCallback(async () => {
+    await logout();
+    setIsSidebarOpen(false);
+    router.push(ROUTES.HOME.index);
+  }, [logout, router]);
 
   return (
-    <XStack
-      top={0}
-      zIndex={200}
-      height={80}
-      paddingHorizontal={60}
-      alignItems="center"
-      justifyContent="space-between"
-      backgroundColor="$myLessonsTopNavBackground"
-      borderBottomWidth={1}
-      borderBottomColor="$myLessonsTopNavBorder"
-      style={{
-        position: 'sticky',
-        backdropFilter: 'blur(14px) saturate(140%)',
-        backgroundImage: `linear-gradient(90deg, ${headerTheme.webHeaderBgStart}, ${headerTheme.webHeaderBgEnd})`,
-        boxShadow: `${headerTheme.webHeaderContainerShadow}`,
-        transition: 'background-image 420ms cubic-bezier(0.22,1,0.36,1), box-shadow 420ms cubic-bezier(0.22,1,0.36,1), border-color 320ms ease',
-      }}
-    >
-      <XStack alignItems="center" gap={10}>
-        <Link href={ROUTES.HOME.index} style={{ color: 'inherit', textDecoration: 'none' }}>
-          <XStack
-            alignItems="center"
-            gap={10}
-            borderRadius={999}
-            paddingVertical={6}
-            paddingHorizontal={10}
-            backgroundColor="$webHeaderLogoChipBg"
-            borderWidth={1}
-            borderColor="$webHeaderLogoChipBorder"
-            style={{ transition: 'all 320ms cubic-bezier(0.22,1,0.36,1)' }}
-          >
-            <LogoIcon />
-            <Text color="$myLessonsBrandText" fontSize={18} fontWeight="700" lineHeight={24}>
-              TutorMatch
-            </Text>
-          </XStack>
-        </Link>
-      </XStack>
+    <>
+      <XStack
+        top={0}
+        zIndex={200}
+        height={HEADER_CONFIG.height.desktop}
+        paddingHorizontal={HEADER_CONFIG.padding.desktop}
+        alignItems="center"
+        justifyContent="space-between"
+        backgroundColor="$myLessonsTopNavBackground"
+        borderBottomWidth={1}
+        borderBottomColor="$myLessonsTopNavBorder"
+        $xs={{
+          height: HEADER_CONFIG.height.mobile,
+          paddingHorizontal: HEADER_CONFIG.padding.mobile,
+        }}
+        $sm={{
+          height: HEADER_CONFIG.height.tablet,
+          paddingHorizontal: HEADER_CONFIG.padding.tablet,
+        }}
+        style={{
+          position: 'sticky',
+          backdropFilter: HEADER_CONFIG.backdrop.blur,
+          backgroundImage: `linear-gradient(90deg, ${headerTheme.webHeaderBgStart}, ${headerTheme.webHeaderBgEnd})`,
+          boxShadow: `${headerTheme.webHeaderContainerShadow}`,
+          transition: `background-image ${HEADER_CONFIG.transition.duration} ${HEADER_CONFIG.transition.easing}, box-shadow ${HEADER_CONFIG.transition.duration} ${HEADER_CONFIG.transition.easing}, border-color ${HEADER_CONFIG.transition.borderDuration} ease`,
+        }}
+      >
+        <XStack
+          alignItems="center"
+          gap={10}
+          $xs={{ gap: 6 }}
+          $sm={{ gap: 8 }}
+        >
+          {isDashboard && isMobile ? (
+            <XStack
+              alignItems="center"
+              gap={HEADER_CONFIG.menu.dashboardGap}
+            >
+              <Button
+                chromeless
+                onPress={handleMenuPress}
+                padding={HEADER_CONFIG.menu.buttonPadding}
+                borderRadius={HEADER_CONFIG.menu.buttonBorderRadius}
+                hoverStyle={{
+                  backgroundColor: '$dashboardTutorSidebarItemHover',
+                }}
+              >
+                <MenuIcon
+                  size={HEADER_CONFIG.menu.iconSize}
+                  color={headerTheme.webHeaderToggleText || '#111827'}
+                />
+              </Button>
+              <Text
+                color="$myLessonsBrandText"
+                fontSize={HEADER_CONFIG.logo.mobileDashboardFontSize}
+                fontWeight="700"
+              >
+                TutorMatch
+              </Text>
+            </XStack>
+          ) : (
+            <Link
+              href={ROUTES.HOME.index}
+              style={{ textDecoration: 'none' }}
+            >
+              <XStack
+                alignItems="center"
+                gap={10}
+                borderRadius={HEADER_CONFIG.logo.borderRadius}
+                paddingVertical={HEADER_CONFIG.logo.padding.vertical}
+                paddingHorizontal={HEADER_CONFIG.logo.padding.horizontal}
+                backgroundColor="$webHeaderLogoChipBg"
+                borderWidth={1}
+                borderColor="$webHeaderLogoChipBorder"
+                $xs={{
+                  paddingVertical: HEADER_CONFIG.logo.mobilePadding.vertical,
+                  paddingHorizontal: HEADER_CONFIG.logo.mobilePadding.horizontal,
+                  gap: 0,
+                }}
+                $sm={{
+                  paddingVertical: HEADER_CONFIG.logo.mobilePadding.vertical,
+                  paddingHorizontal: HEADER_CONFIG.logo.mobilePadding.horizontal,
+                  gap: 0,
+                }}
+                style={{
+                  transition: `all ${HEADER_CONFIG.transition.borderDuration} ${HEADER_CONFIG.transition.easing}`,
+                  cursor: 'pointer',
+                }}
+                className="mobile-header-logo"
+                hoverStyle={{
+                  transform: 'scale(1.05)',
+                  boxShadow: '0 4px 12px rgba(59, 130, 246, 0.2)',
+                }}
+                pressStyle={{
+                  transform: 'scale(0.95)',
+                }}
+              >
+                <LogoIcon size={HEADER_CONFIG.logo.size} />
+                <Text
+                  color="$myLessonsBrandText"
+                  fontSize={HEADER_CONFIG.logo.fontSize}
+                  fontWeight="700"
+                  lineHeight={HEADER_CONFIG.logo.lineHeight}
+                  display="block"
+                  $xs={{ display: 'none' }}
+                  $sm={{ display: 'none' }}
+                >
+                  TutorMatch
+                </Text>
+              </XStack>
+            </Link>
+          )}
+        </XStack>
 
-      <XStack gap={30} alignItems="center">
-        {HEADER_NAV.map((item) => (
-          <HeaderNavLink
-            key={item.href}
-            href={item.href}
-            label={t(item.labelKey)}
-            active={pathname === item.href}
-          />
-        ))}
-      </XStack>
-
-      <XStack alignItems="center" gap={10}>
-        {!isAuthenticated ? <LoginButton /> : null}
-
-        <HeaderLocaleToggle locale={locale} onToggle={toggleLocale} iconColor={headerTheme.webHeaderToggleText} />
-
-        <HeaderThemeToggle isDark={themeMode === 'dark'} onToggleAction={toggleTheme} />
-
-        {isAuthenticated && user?.avatar ? (
-          <XStack
-            borderWidth={1}
-            borderColor="$myLessonsTopNavBorder"
-            borderRadius={999}
-            backgroundColor="transparent"
-            padding={4}
-            cursor="pointer"
-            onPress={goToDashboard}
-          >
-            <img
-              src={user.avatar}
-              alt={user.username ?? 'User avatar'}
-              style={{
-                width: 36,
-                height: 36,
-                borderRadius: '999px',
-                objectFit: 'cover',
-                border: `2px solid ${headerTheme.webHeaderAvatarBorder}`,
-                cursor: 'pointer',
-              }}
+        <XStack
+          gap={HEADER_CONFIG.nav.gap.desktop}
+          alignItems="center"
+          $xs={{ display: 'none' }}
+          $sm={{ display: 'none' }}
+        >
+          {HEADER_NAV.map((item) => (
+            <HeaderNavLink
+              key={item.href}
+              href={item.href}
+              label={t(item.labelKey)}
+              active={pathname === item.href}
             />
-          </XStack>
-        ) : null}
+          ))}
+        </XStack>
+
+        <XStack
+          gap={12}
+          alignItems="center"
+          display="none"
+          $xs={{ display: 'flex', gap: HEADER_CONFIG.nav.gap.mobile }}
+          $sm={{ display: 'flex', gap: HEADER_CONFIG.nav.gap.tablet }}
+        >
+          <Link
+            href={HEADER_NAV[0].href}
+            style={{ color: 'inherit', textDecoration: 'none' }}
+          >
+            <Text
+              color={
+                pathname === HEADER_NAV[0].href ? '$myLessonsNavActive' : '$myLessonsNavInactive'
+              }
+              fontSize={HEADER_CONFIG.nav.fontSize.desktop}
+              fontWeight={pathname === HEADER_NAV[0].href ? '700' : '500'}
+              $xs={{ fontSize: HEADER_CONFIG.nav.fontSize.mobile }}
+              $sm={{ fontSize: HEADER_CONFIG.nav.fontSize.tablet }}
+            >
+              {t(HEADER_NAV[0].labelKey)}
+            </Text>
+          </Link>
+        </XStack>
+
+        <XStack
+          alignItems="center"
+          gap={10}
+          $xs={{ gap: 4 }}
+          $sm={{ gap: 5 }}
+        >
+          {!isAuthenticated ? <LoginButton /> : null}
+
+          <HeaderLocaleToggle
+            locale={locale}
+            onToggle={toggleLocale}
+            iconColor={headerTheme.webHeaderToggleText}
+          />
+
+          <HeaderThemeToggle
+            isDark={themeMode === 'dark'}
+            onToggleAction={toggleTheme}
+          />
+
+          {isAuthenticated && user?.avatar ? (
+            <XStack
+              borderWidth={1}
+              borderColor="$myLessonsTopNavBorder"
+              borderRadius={999}
+              backgroundColor="transparent"
+              padding={HEADER_CONFIG.avatar.padding.desktop}
+              cursor="pointer"
+              onPress={goToDashboard}
+              $xs={{ padding: HEADER_CONFIG.avatar.padding.mobile }}
+              $sm={{ padding: HEADER_CONFIG.avatar.padding.tablet }}
+            >
+              <img
+                src={user.avatar}
+                alt={user.username ?? 'User avatar'}
+                style={{
+                  width: HEADER_CONFIG.avatar.size.desktop,
+                  height: HEADER_CONFIG.avatar.size.desktop,
+                  borderRadius: '999px',
+                  objectFit: 'cover',
+                  border: `${HEADER_CONFIG.avatar.borderWidth}px solid ${headerTheme.webHeaderAvatarBorder}`,
+                  cursor: 'pointer',
+                }}
+                className="mobile-avatar"
+              />
+            </XStack>
+          ) : null}
+        </XStack>
       </XStack>
-    </XStack>
-  )
+
+      <DashboardMobileDrawer
+        isOpen={isDashboard && isMobile && isSidebarOpen}
+        onClose={handleCloseSidebar}
+        items={visibleMenuItems}
+        pathname={pathname}
+        activeIconColor={dashboardTheme.dashboardTutorFilterActiveBg || '#3B82F6'}
+        inactiveIconColor={dashboardTheme.dashboardTutorTextSecondary || '#6B7280'}
+        logoutIconColor={dashboardTheme.myLessonsSidebarLogoutIcon || '#EF4444'}
+        onLogout={handleLogout}
+        t={tDashboard}
+      />
+    </>
+  );
 }

--- a/packages/app/features/dashboard/mobile-drawer/DashboardMobileDrawer.tsx
+++ b/packages/app/features/dashboard/mobile-drawer/DashboardMobileDrawer.tsx
@@ -1,0 +1,108 @@
+import { YStack, XStack, Text } from '@mezon-tutors/app/ui';
+import { LogoIcon } from '@mezon-tutors/app/ui/icons';
+import { type DashboardMenuItem } from '@mezon-tutors/shared/src/constants/dashboard';
+import { HEADER_CONFIG } from '@mezon-tutors/shared/src/constants/header';
+import { DashboardMenuList } from '../shared/DashboardMenuList';
+
+type DashboardMobileDrawerProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  items: DashboardMenuItem[];
+  pathname: string;
+  activeIconColor: string;
+  inactiveIconColor: string;
+  logoutIconColor: string;
+  onLogout: () => void;
+  t: (key: string) => string;
+};
+
+export function DashboardMobileDrawer({
+  isOpen,
+  onClose,
+  items,
+  pathname,
+  activeIconColor,
+  inactiveIconColor,
+  logoutIconColor,
+  onLogout,
+  t,
+}: DashboardMobileDrawerProps) {
+  if (!isOpen) return null;
+
+  const handleItemPress = (item: DashboardMenuItem) => {
+    if (item.type === 'action') {
+      onLogout();
+    } else {
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      <YStack
+        position="absolute"
+        top={0}
+        left={0}
+        right={0}
+        bottom={0}
+        backgroundColor={`rgba(0, 0, 0, ${HEADER_CONFIG.backdrop.overlayOpacity})`}
+        zIndex={998}
+        onPress={onClose}
+        style={{ position: 'fixed' as never, cursor: 'pointer' }}
+      />
+      <YStack
+        position="absolute"
+        top={0}
+        left={0}
+        bottom={0}
+        width={HEADER_CONFIG.drawer.width}
+        backgroundColor="$dashboardTutorSidebarBackground"
+        borderRightWidth={1}
+        borderRightColor="$dashboardTutorSidebarBorder"
+        zIndex={999}
+        style={{ position: 'fixed' as never }}
+      >
+        <XStack
+          alignItems="center"
+          gap={10}
+          padding={HEADER_CONFIG.drawer.padding}
+          paddingVertical={HEADER_CONFIG.drawer.padding}
+          borderBottomWidth={1}
+          borderBottomColor="$dashboardTutorSidebarBorder"
+        >
+          <LogoIcon size={HEADER_CONFIG.drawer.logoSize} />
+          <Text
+            color="$myLessonsBrandText"
+            fontSize={HEADER_CONFIG.drawer.logoFontSize}
+            fontWeight="700"
+          >
+            TutorMatch
+          </Text>
+        </XStack>
+
+        <YStack
+          flex={1}
+          padding={HEADER_CONFIG.drawer.padding}
+          gap={HEADER_CONFIG.drawer.itemGap}
+        >
+          <DashboardMenuList
+            items={items}
+            pathname={pathname}
+            activeIconColor={activeIconColor}
+            inactiveIconColor={inactiveIconColor}
+            logoutIconColor={logoutIconColor}
+            t={t}
+            onItemPress={handleItemPress}
+            config={{
+              defaultIconSize: HEADER_CONFIG.drawer.iconSize.default,
+              bookingRequestsIconSize: HEADER_CONFIG.drawer.iconSize.bookingRequests,
+              itemPaddingVertical: HEADER_CONFIG.drawer.itemPadding.vertical,
+              itemPaddingHorizontal: HEADER_CONFIG.drawer.itemPadding.horizontal,
+              itemBorderRadius: HEADER_CONFIG.drawer.itemBorderRadius,
+            }}
+          />
+        </YStack>
+      </YStack>
+    </>
+  );
+}

--- a/packages/app/features/dashboard/shared/DashboardMenuList.tsx
+++ b/packages/app/features/dashboard/shared/DashboardMenuList.tsx
@@ -1,0 +1,110 @@
+import Link from 'next/link';
+import { Button, Text, YStack } from '@mezon-tutors/app/ui';
+import type { DashboardMenuItem } from '@mezon-tutors/shared/src/constants/dashboard';
+import { getDashboardMenuItemDisplay } from '../utils/menu-item';
+
+type DashboardMenuListConfig = {
+  defaultIconSize: number;
+  bookingRequestsIconSize: number;
+  itemPaddingVertical: number;
+  itemPaddingHorizontal: number;
+  itemBorderRadius: number;
+};
+
+type DashboardMenuListProps = {
+  items: DashboardMenuItem[];
+  pathname: string;
+  activeIconColor: string;
+  inactiveIconColor: string;
+  logoutIconColor: string;
+  t: (key: string) => string;
+  onItemPress?: (item: DashboardMenuItem) => void;
+  config: DashboardMenuListConfig;
+};
+
+export function DashboardMenuList({
+  items,
+  pathname,
+  activeIconColor,
+  inactiveIconColor,
+  logoutIconColor,
+  t,
+  onItemPress,
+  config,
+}: DashboardMenuListProps) {
+  return (
+    <>
+      {items.map((item) => {
+        const { active, Icon, iconColor, labelColor } = getDashboardMenuItemDisplay(item, {
+          pathname,
+          activeIconColor,
+          inactiveIconColor,
+          logoutIconColor,
+        });
+        const iconSize =
+          item.iconKey === 'bookingRequests'
+            ? config.bookingRequestsIconSize
+            : config.defaultIconSize;
+
+        const content = (
+          <Button
+            onPress={() => onItemPress?.(item)}
+            borderWidth={active ? 1 : 0}
+            borderColor="$dashboardTutorSidebarItemActiveBorder"
+            backgroundColor={active ? '$dashboardTutorSidebarItemActiveBg' : 'transparent'}
+            color={labelColor}
+            paddingVertical={config.itemPaddingVertical}
+            paddingHorizontal={config.itemPaddingHorizontal}
+            borderRadius={config.itemBorderRadius}
+            flexDirection="row"
+            alignItems="center"
+            gap="$2"
+            justifyContent="flex-start"
+            width="100%"
+            hoverStyle={{
+              backgroundColor: '$dashboardTutorSidebarItemHover',
+              borderColor: '$dashboardTutorSidebarItemActiveBorder',
+            }}
+          >
+            <Icon
+              size={iconSize}
+              color={iconColor}
+            />
+            <Text
+              color={labelColor}
+              fontWeight={active ? '700' : '500'}
+            >
+              {t(`sidebar.${item.labelKey}`)}
+            </Text>
+          </Button>
+        );
+
+        if (item.type === 'link' && item.href) {
+          return (
+            <Link
+              key={item.key}
+              href={item.href}
+              style={{ textDecoration: 'none', width: '100%' }}
+            >
+              {content}
+            </Link>
+          );
+        }
+
+        return (
+          <YStack
+            key={item.key}
+            width="100%"
+          >
+            {content}
+          </YStack>
+        );
+      })}
+
+      <YStack
+        marginTop="auto"
+        width="100%"
+      />
+    </>
+  );
+}

--- a/packages/app/features/dashboard/sidebar/DashboardSidebar.tsx
+++ b/packages/app/features/dashboard/sidebar/DashboardSidebar.tsx
@@ -1,0 +1,64 @@
+import { YStack } from '@mezon-tutors/app/ui';
+import {
+  type DashboardMenuItem,
+  DASHBOARD_SIDEBAR_CONFIG,
+} from '@mezon-tutors/shared/src/constants/dashboard';
+import { DashboardMenuList } from '../shared/DashboardMenuList';
+
+type DashboardSidebarProps = {
+  items: DashboardMenuItem[];
+  pathname: string;
+  activeIconColor: string;
+  inactiveIconColor: string;
+  logoutIconColor: string;
+  onLogout: () => void;
+  t: (key: string) => string;
+};
+
+export function DashboardSidebar({
+  items,
+  pathname,
+  activeIconColor,
+  inactiveIconColor,
+  logoutIconColor,
+  onLogout,
+  t,
+}: DashboardSidebarProps) {
+  const handleItemPress = (item: DashboardMenuItem) => {
+    if (item.type === 'action') {
+      onLogout();
+    }
+  };
+
+  return (
+    <YStack
+      width={DASHBOARD_SIDEBAR_CONFIG.width}
+      minWidth={DASHBOARD_SIDEBAR_CONFIG.width}
+      backgroundColor="$dashboardTutorSidebarBackground"
+      borderRightWidth={1}
+      borderRightColor="$dashboardTutorSidebarBorder"
+      padding={DASHBOARD_SIDEBAR_CONFIG.padding.container}
+      gap="$3"
+      minHeight="100vh"
+      $xs={{ display: 'none' }}
+      $sm={{ display: 'none' }}
+    >
+      <DashboardMenuList
+        items={items}
+        pathname={pathname}
+        activeIconColor={activeIconColor}
+        inactiveIconColor={inactiveIconColor}
+        logoutIconColor={logoutIconColor}
+        t={t}
+        onItemPress={handleItemPress}
+        config={{
+          defaultIconSize: DASHBOARD_SIDEBAR_CONFIG.iconSizes.default,
+          bookingRequestsIconSize: DASHBOARD_SIDEBAR_CONFIG.iconSizes.bookingRequests,
+          itemPaddingVertical: DASHBOARD_SIDEBAR_CONFIG.padding.item.vertical,
+          itemPaddingHorizontal: DASHBOARD_SIDEBAR_CONFIG.padding.item.horizontal,
+          itemBorderRadius: DASHBOARD_SIDEBAR_CONFIG.borderRadius,
+        }}
+      />
+    </YStack>
+  );
+}

--- a/packages/app/features/dashboard/utils/menu-item.ts
+++ b/packages/app/features/dashboard/utils/menu-item.ts
@@ -1,0 +1,47 @@
+import {
+  BookingRequestIcon,
+  CalendarIcon,
+  DocumentIcon,
+  LogoutIcon,
+} from '@mezon-tutors/app/ui/icons';
+import type { ComponentType } from 'react';
+import type {
+  DashboardMenuIconKey,
+  DashboardMenuItem,
+} from '@mezon-tutors/shared/src/constants/dashboard';
+
+type IconComponent = ComponentType<{ size?: number; color?: string }>;
+
+type MenuDisplayOptions = {
+  pathname: string;
+  activeIconColor: string;
+  inactiveIconColor: string;
+  logoutIconColor: string;
+};
+
+export const DASHBOARD_ICON_COMPONENTS: Record<DashboardMenuIconKey, IconComponent> = {
+  document: DocumentIcon,
+  bookingRequests: BookingRequestIcon,
+  calendar: CalendarIcon,
+  logout: LogoutIcon,
+};
+
+export function getDashboardMenuItemDisplay(item: DashboardMenuItem, options: MenuDisplayOptions) {
+  const active = item.type === 'link' && !!item.href && options.pathname === item.href;
+  const isLogoutItem = item.type === 'action';
+
+  return {
+    active,
+    Icon: DASHBOARD_ICON_COMPONENTS[item.iconKey],
+    iconColor: isLogoutItem
+      ? options.logoutIconColor
+      : active
+        ? options.activeIconColor
+        : options.inactiveIconColor,
+    labelColor: isLogoutItem
+      ? '$myLessonsSidebarLogoutText'
+      : active
+        ? '$dashboardTutorFilterActiveBg'
+        : '$dashboardTutorTextSecondary',
+  };
+}

--- a/packages/app/features/home/my-lessons/components/MyLessonsCalendarSection.tsx
+++ b/packages/app/features/home/my-lessons/components/MyLessonsCalendarSection.tsx
@@ -1,7 +1,6 @@
 import { YStack } from '@mezon-tutors/app/ui';
 import type { LessonItem, MyLessonsCalendarMeta } from '../types';
 import { MyLessonsCalendarCard } from './MyLessonsCalendarCard';
-import { MyLessonsPromoCard } from './MyLessonsPromoCard';
 
 type MyLessonsCalendarSectionProps = {
   calendar: MyLessonsCalendarMeta;
@@ -13,7 +12,6 @@ type MyLessonsCalendarSectionProps = {
 export function MyLessonsCalendarSection({ calendar, lessons, onPrevWeek, onNextWeek }: MyLessonsCalendarSectionProps) {
   return (
     <YStack gap="$5" width="100%" maxWidth={1032} minWidth={0} alignSelf="center">
-      <MyLessonsPromoCard />
       <MyLessonsCalendarCard lessons={lessons} calendar={calendar} onPrevWeek={onPrevWeek} onNextWeek={onNextWeek} />
     </YStack>
   );

--- a/packages/app/features/home/my-lessons/components/MyLessonsHeader.tsx
+++ b/packages/app/features/home/my-lessons/components/MyLessonsHeader.tsx
@@ -17,25 +17,31 @@ export function MyLessonsHeader({ activeTab, onTabChange }: MyLessonsHeaderProps
   const t = useTranslations('MyLessons');
 
   return (
-    <YStack gap="$4">
+    <YStack
+      gap="$4"
+      $xs={{ gap: '$3' }}
+      $sm={{ gap: '$3' }}
+    >
       <XStack
         width="100%"
         justifyContent="space-between"
-        alignItems="center"
+        alignItems="flex-start"
         flexDirection="row"
-        gap="$3"
-        $xs={{ alignItems: 'flex-start', flexDirection: 'column' }}
-        $sm={{ alignItems: 'flex-start', flexDirection: 'column' }}
-        $md={{ alignItems: 'flex-start', flexDirection: 'column' }}
+        flexWrap="nowrap"
+        gap="$2"
+        $xs={{ gap: '$1.5', alignItems: 'flex-start' }}
       >
         <Text
           color="$myLessonsHeaderTitle"
           fontSize={52}
           lineHeight={56}
           fontWeight="800"
-          $xs={{ fontSize: 38, lineHeight: 42 }}
-          $sm={{ fontSize: 38, lineHeight: 42 }}
+          flex={1}
+          flexShrink={1}
+          $xs={{ fontSize: 18, lineHeight: 22, fontWeight: '700' }}
+          $sm={{ fontSize: 24, lineHeight: 28, fontWeight: '700' }}
           $md={{ fontSize: 38, lineHeight: 42 }}
+          className="my-lessons-title-mobile"
         >
           {t('header.title')}
         </Text>
@@ -50,12 +56,29 @@ export function MyLessonsHeader({ activeTab, onTabChange }: MyLessonsHeaderProps
           }}
           color="$myLessonsPrimaryButtonText"
           paddingHorizontal="$5"
-          alignSelf="auto"
-          $xs={{ alignSelf: 'stretch' }}
-          $sm={{ alignSelf: 'stretch' }}
-          $md={{ alignSelf: 'stretch' }}
+          paddingVertical="$3"
+          flexShrink={0}
+          $xs={{
+            paddingHorizontal: 6,
+            paddingVertical: 3,
+            borderRadius: 6,
+            minWidth: 'auto',
+          }}
+          $sm={{
+            paddingHorizontal: '$2',
+            paddingVertical: '$1.5',
+            borderRadius: 8,
+          }}
         >
-          {t('header.scheduleLesson')}
+          <Text
+            color="$myLessonsPrimaryButtonText"
+            fontSize={15}
+            fontWeight="600"
+            $xs={{ fontSize: 9, lineHeight: 11 }}
+            $sm={{ fontSize: 11, lineHeight: 14 }}
+          >
+            {t('header.scheduleLesson')}
+          </Text>
         </Button>
       </XStack>
 
@@ -66,27 +89,38 @@ export function MyLessonsHeader({ activeTab, onTabChange }: MyLessonsHeaderProps
         alignItems="flex-end"
         gap="$4"
         flexWrap="wrap"
+        role="tablist"
+        $xs={{ gap: '$3' }}
+        $sm={{ gap: '$3' }}
       >
         {TAB_ITEMS.map((item) => {
           const isActive = item.value === activeTab;
 
           return (
-            <YStack
+            <Button
+              chromeless
               key={item.value}
               onPress={() => onTabChange(item.value)}
               paddingVertical="$2"
               borderBottomWidth={2}
               borderBottomColor={isActive ? '$myLessonsNavActive' : 'transparent'}
-              cursor="pointer"
+              borderRadius={0}
+              alignItems="flex-start"
+              aria-selected={isActive}
+              role="tab"
+              $xs={{ paddingVertical: '$1.5' }}
+              $sm={{ paddingVertical: '$1.5' }}
             >
               <Text
                 fontSize={14}
                 fontWeight={isActive ? '700' : '500'}
                 color={isActive ? '$myLessonsNavActive' : '$myLessonsNavInactive'}
+                $xs={{ fontSize: 13 }}
+                $sm={{ fontSize: 13 }}
               >
                 {t(item.label)}
               </Text>
-            </YStack>
+            </Button>
           );
         })}
       </XStack>

--- a/packages/app/features/home/my-lessons/components/MyLessonsLessonsPanel.tsx
+++ b/packages/app/features/home/my-lessons/components/MyLessonsLessonsPanel.tsx
@@ -2,22 +2,12 @@ import { Button, Text, XStack, YStack } from '@mezon-tutors/app/ui';
 import type { ReactNode } from 'react';
 import { useTranslations } from 'next-intl';
 import { Image } from 'tamagui';
+import { StarOutlineIcon } from '@mezon-tutors/app/ui/icons';
+import { DEFAULT_AVATAR_URL } from '@mezon-tutors/shared/src/constants/my-lesson';
 import type { LessonItem } from '../types';
 
-function getInitials(name: string): string {
-  const tokens = name.trim().split(/\s+/).filter(Boolean);
-  if (!tokens.length) {
-    return 'NA';
-  }
-
-  return tokens
-    .slice(0, 2)
-    .map((token) => token[0]?.toUpperCase() ?? '')
-    .join('');
-}
-
 function LessonPersonBadge({ name, avatar }: { name: string; avatar?: string }) {
-  const avatarUri = avatar?.trim() || '';
+  const avatarUri = avatar?.trim() || DEFAULT_AVATAR_URL;
 
   return (
     <YStack
@@ -31,13 +21,13 @@ function LessonPersonBadge({ name, avatar }: { name: string; avatar?: string }) 
       borderColor="$myLessonsAvatarBorder"
       overflow="hidden"
     >
-      {avatarUri ? (
-        <Image source={{ uri: avatarUri }} width={40} height={40} borderRadius={999} accessibilityLabel={name} />
-      ) : (
-        <Text color="$myLessonsAvatarText" fontSize={11} fontWeight="700">
-          {getInitials(name)}
-        </Text>
-      )}
+      <Image 
+        source={{ uri: avatarUri }} 
+        width={40} 
+        height={40} 
+        borderRadius={999} 
+        accessibilityLabel={name} 
+      />
     </YStack>
   );
 }
@@ -65,7 +55,6 @@ function PastLessonListItem({
       justifyContent="space-between"
       alignItems="center"
       gap="$3"
-      flexWrap="wrap"
     >
       <XStack alignItems="center" gap="$2.5" flex={1} minWidth={220}>
         <LessonPersonBadge name={lesson.tutor} avatar={lesson.tutorAvatar} />
@@ -79,7 +68,7 @@ function PastLessonListItem({
         </YStack>
       </XStack>
 
-      <XStack alignItems="center" gap="$2">
+      <XStack alignItems="center" gap="$2.5" marginLeft="auto">
         {rated ? (
           <YStack
             borderWidth={1}
@@ -90,9 +79,12 @@ function PastLessonListItem({
             backgroundColor="$myLessonsLessonsRatingBackground"
             alignItems="center"
           >
-            <Text color="$myLessonsLessonsRatingText" fontSize={11} fontWeight="700">
-              {'☆ 4.8'}
-            </Text>
+            <XStack alignItems="center" gap={2}>
+              <StarOutlineIcon size={11} color="$myLessonsLessonsRatingText" />
+              <Text color="$myLessonsLessonsRatingText" fontSize={11} fontWeight="700">
+                {lesson.rating?.toFixed(1) ?? '5.0'}
+              </Text>
+            </XStack>
             <Text color="$myLessonsLessonsRatingText" fontSize={10} fontWeight="600">
               {ratedLabel}
             </Text>
@@ -110,7 +102,12 @@ function PastLessonListItem({
             fontSize={11}
             fontWeight="600"
           >
-            {`☆ ${rateLabel}`}
+            <XStack alignItems="center" gap={2}>
+              <StarOutlineIcon size={11} color="$myLessonsLessonsActionSecondaryText" />
+              <Text color="$myLessonsLessonsActionSecondaryText" fontSize={11} fontWeight="600">
+                {rateLabel}
+              </Text>
+            </XStack>
           </Button>
         )}
 

--- a/packages/app/features/home/my-lessons/components/MyLessonsMobileCalendar.tsx
+++ b/packages/app/features/home/my-lessons/components/MyLessonsMobileCalendar.tsx
@@ -63,7 +63,7 @@ function WeekDayButton({ day, date, isActive, isToday, onPress }: WeekDayButtonP
       width={config.width}
       flexDirection="column"
       alignItems="center"
-      gap={2}
+      gap={config.contentGap}
       position="relative"
       flexShrink={0}
       className="week-day-button"

--- a/packages/app/features/home/my-lessons/components/MyLessonsMobileCalendar.tsx
+++ b/packages/app/features/home/my-lessons/components/MyLessonsMobileCalendar.tsx
@@ -1,0 +1,442 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Button, Text, XStack, YStack, ScrollView } from '@mezon-tutors/app/ui';
+import { ChevronLeftIcon, ChevronRightIcon, ClockCircleIcon } from '@mezon-tutors/app/ui/icons';
+import { useTranslations, useLocale } from 'next-intl';
+import { Image, useTheme } from 'tamagui';
+import {
+  DEFAULT_AVATAR_URL,
+  MY_LESSONS_MOBILE_CONFIG,
+} from '@mezon-tutors/shared/src/constants/my-lesson';
+import { formatWeekDays, formatCalendarTitle } from '../../../calendar/utils/format-locale';
+import type { LessonCategory, LessonItem, MyLessonsCalendarMeta } from '../types';
+
+function LessonPersonBadge({ name, avatar }: { name: string; avatar?: string }) {
+  const avatarUri = avatar?.trim() || DEFAULT_AVATAR_URL;
+  const config = MY_LESSONS_MOBILE_CONFIG.card.avatar;
+
+  return (
+    <YStack
+      width={config.size}
+      height={config.size}
+      borderRadius={config.borderRadius}
+      alignItems="center"
+      justifyContent="center"
+      backgroundColor="$myLessonsAvatarBackground"
+      borderWidth={1}
+      borderColor="$myLessonsAvatarBorder"
+      overflow="hidden"
+    >
+      <Image
+        source={{ uri: avatarUri }}
+        width={config.size}
+        height={config.size}
+        borderRadius={config.borderRadius}
+        accessibilityLabel={name}
+      />
+    </YStack>
+  );
+}
+
+type WeekDayButtonProps = {
+  day: string;
+  date: string;
+  isActive: boolean;
+  isToday: boolean;
+  onPress: () => void;
+};
+
+function WeekDayButton({ day, date, isActive, isToday, onPress }: WeekDayButtonProps) {
+  const config = MY_LESSONS_MOBILE_CONFIG.weekDay;
+
+  return (
+    <Button
+      chromeless
+      onPress={onPress}
+      paddingVertical={config.padding.vertical}
+      paddingHorizontal={config.padding.horizontal}
+      borderRadius={config.borderRadius}
+      backgroundColor={isActive ? '$myLessonsPrimaryButton' : 'transparent'}
+      borderWidth={isToday && !isActive ? 1 : 0}
+      borderColor={isToday && !isActive ? '$myLessonsPrimaryButton' : 'transparent'}
+      minWidth={config.minWidth}
+      maxWidth={config.maxWidth}
+      width={config.width}
+      flexDirection="column"
+      alignItems="center"
+      gap={2}
+      position="relative"
+      flexShrink={0}
+      className="week-day-button"
+    >
+      <Text
+        color={
+          isActive
+            ? '$myLessonsPrimaryButtonText'
+            : isToday
+              ? '$myLessonsPrimaryButton'
+              : '$myLessonsLessonsSecondaryText'
+        }
+        fontSize={config.dayFontSize}
+        lineHeight={config.dayLineHeight}
+        fontWeight="600"
+        textTransform="uppercase"
+        className="week-day-label"
+      >
+        {day}
+      </Text>
+      <Text
+        color={
+          isActive
+            ? '$myLessonsPrimaryButtonText'
+            : isToday
+              ? '$myLessonsPrimaryButton'
+              : '$myLessonsLessonsPrimaryText'
+        }
+        fontSize={config.dateFontSize}
+        fontWeight="700"
+        lineHeight={config.dateLineHeight}
+        className="week-day-date"
+      >
+        {date}
+      </Text>
+    </Button>
+  );
+}
+
+type MobileLessonCardProps = {
+  lesson: LessonItem;
+  joinLabel: string;
+};
+
+function MobileLessonCard({ lesson, joinLabel }: MobileLessonCardProps) {
+  const theme = useTheme();
+  const clockIconColor = theme.myLessonsLessonsSecondaryText?.val;
+  const config = MY_LESSONS_MOBILE_CONFIG.card;
+
+  return (
+    <YStack
+      width="100%"
+      borderWidth={1}
+      borderColor="$myLessonsLessonsCardBorder"
+      borderRadius={config.borderRadius}
+      backgroundColor="$myLessonsLessonsCardBackground"
+      padding={config.padding}
+      gap={config.gap}
+    >
+      <XStack
+        alignItems="center"
+        gap={10}
+        flex={1}
+      >
+        <LessonPersonBadge
+          name={lesson.tutor}
+          avatar={lesson.tutorAvatar}
+        />
+        <YStack
+          gap={3}
+          flex={1}
+        >
+          <Text
+            color="$myLessonsPrimaryButton"
+            fontSize={config.subject.fontSize}
+            lineHeight={config.subject.lineHeight}
+            fontWeight="800"
+            textTransform="uppercase"
+          >
+            {lesson.subject}
+          </Text>
+          <Text
+            color="$myLessonsLessonsPrimaryText"
+            fontSize={config.tutor.fontSize}
+            lineHeight={config.tutor.lineHeight}
+          >
+            {lesson.tutor}
+          </Text>
+          <XStack
+            alignItems="center"
+            gap={4}
+          >
+            <ClockCircleIcon
+              size={config.time.iconSize}
+              color={clockIconColor}
+            />
+            <Text
+              color="$myLessonsLessonsSecondaryText"
+              fontSize={config.time.fontSize}
+              lineHeight={config.time.lineHeight}
+            >
+              {lesson.timeLabel}
+            </Text>
+          </XStack>
+        </YStack>
+        <Button
+          variant="primary"
+          backgroundColor="$myLessonsPrimaryButton"
+          borderColor="$myLessonsPrimaryButton"
+          color="$myLessonsPrimaryButtonText"
+          borderRadius={config.button.borderRadius}
+          paddingVertical={config.button.padding.vertical}
+          paddingHorizontal={config.button.padding.horizontal}
+          fontSize={config.button.fontSize}
+          fontWeight="700"
+        >
+          {joinLabel}
+        </Button>
+      </XStack>
+    </YStack>
+  );
+}
+
+type CategoryFilterProps = {
+  categories: LessonCategory[];
+  selectedCategory: LessonCategory | 'all';
+  onSelectCategory: (category: LessonCategory | 'all') => void;
+  allLabel: string;
+  lessonsLabel: string;
+};
+
+function CategoryFilter({
+  categories,
+  selectedCategory,
+  onSelectCategory,
+  allLabel,
+  lessonsLabel,
+}: CategoryFilterProps) {
+  const config = MY_LESSONS_MOBILE_CONFIG.category;
+
+  const renderCategoryButton = (category: LessonCategory | 'all', label: string) => {
+    const isSelected = selectedCategory === category;
+
+    return (
+      <Button
+        key={category}
+        chromeless
+        onPress={() => onSelectCategory(category)}
+        paddingHorizontal={config.padding.horizontal}
+        paddingVertical={config.padding.vertical}
+        borderRadius={config.borderRadius}
+        backgroundColor="transparent"
+        borderWidth={0}
+        flexShrink={0}
+      >
+        <XStack
+          alignItems="center"
+          gap="$1"
+        >
+          <YStack
+            width={config.dotSize}
+            height={config.dotSize}
+            borderRadius={999}
+            backgroundColor={
+              isSelected ? '$myLessonsPrimaryButton' : '$myLessonsLessonsSecondaryText'
+            }
+          />
+          <Text
+            color={isSelected ? '$myLessonsLessonsPrimaryText' : '$myLessonsLessonsSecondaryText'}
+            fontSize={config.fontSize}
+            fontWeight={isSelected ? '700' : '500'}
+            textTransform="uppercase"
+          >
+            {label}
+          </Text>
+        </XStack>
+      </Button>
+    );
+  };
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      width="100%"
+    >
+      <XStack
+        gap="$2.5"
+        paddingRight="$4"
+      >
+        {renderCategoryButton('all', allLabel)}
+        {categories.map((category) =>
+          renderCategoryButton(category, `${category} ${lessonsLabel}`)
+        )}
+      </XStack>
+    </ScrollView>
+  );
+}
+
+type MyLessonsMobileCalendarProps = {
+  calendar: MyLessonsCalendarMeta;
+  lessons: LessonItem[];
+  onPrevWeek?: () => void;
+  onNextWeek?: () => void;
+};
+
+export function MyLessonsMobileCalendar({
+  calendar,
+  lessons,
+  onPrevWeek,
+  onNextWeek,
+}: MyLessonsMobileCalendarProps) {
+  const t = useTranslations('MyLessons');
+  const locale = useLocale();
+  const theme = useTheme();
+  const [selectedDayIndex, setSelectedDayIndex] = useState(() => calendar.currentDayIndex ?? 0);
+  const [selectedCategory, setSelectedCategory] = useState<LessonCategory | 'all'>('all');
+  const config = MY_LESSONS_MOBILE_CONFIG;
+
+  const localizedWeekDays = useMemo(
+    () => formatWeekDays(calendar.weekDays, locale),
+    [calendar.weekDays, locale]
+  );
+
+  const localizedTitle = useMemo(
+    () => formatCalendarTitle(calendar.title, locale),
+    [calendar.title, locale]
+  );
+
+  useEffect(() => {
+    setSelectedDayIndex(calendar.currentDayIndex ?? 0);
+  }, [calendar.currentDayIndex, calendar.title]);
+
+  const selectedDayLessons = useMemo(
+    () => lessons.filter((lesson) => lesson.dayIndex === selectedDayIndex),
+    [lessons, selectedDayIndex]
+  );
+
+  const categories = useMemo(
+    () => Array.from(new Set(selectedDayLessons.map((lesson) => lesson.category))),
+    [selectedDayLessons]
+  );
+
+  useEffect(() => {
+    if (selectedCategory !== 'all' && !categories.includes(selectedCategory)) {
+      setSelectedCategory('all');
+    }
+  }, [categories, selectedCategory]);
+
+  const filteredLessons = useMemo(
+    () =>
+      selectedCategory === 'all'
+        ? selectedDayLessons
+        : selectedDayLessons.filter((lesson) => lesson.category === selectedCategory),
+    [selectedCategory, selectedDayLessons]
+  );
+
+  const chevronColor = theme.myLessonsMonthNav?.val;
+  const currentDayIndex = calendar.currentDayIndex;
+
+  return (
+    <YStack
+      gap={12}
+      width="100%"
+      paddingHorizontal={0}
+      className="mobile-calendar-container"
+    >
+      <XStack
+        alignItems="center"
+        justifyContent="space-between"
+        width="100%"
+        paddingHorizontal={0}
+      >
+        <Button
+          chromeless
+          onPress={onPrevWeek}
+          padding={config.navigation.buttonPadding}
+          borderRadius={config.navigation.buttonBorderRadius}
+          disabled={!onPrevWeek}
+        >
+          <ChevronLeftIcon
+            size={config.navigation.iconSize}
+            color={chevronColor}
+          />
+        </Button>
+
+        <Text
+          color="$myLessonsCalendarTitle"
+          fontSize={config.navigation.titleFontSize}
+          fontWeight="700"
+          textAlign="center"
+          className="month-title"
+        >
+          {localizedTitle}
+        </Text>
+
+        <Button
+          chromeless
+          onPress={onNextWeek}
+          padding={config.navigation.buttonPadding}
+          borderRadius={config.navigation.buttonBorderRadius}
+          disabled={!onNextWeek}
+        >
+          <ChevronRightIcon
+            size={config.navigation.iconSize}
+            color={chevronColor}
+          />
+        </Button>
+      </XStack>
+
+      <XStack
+        gap={6}
+        width="100%"
+        className="week-days-container"
+        flexWrap="nowrap"
+        overflow="visible"
+      >
+        {localizedWeekDays.map((day, index) => (
+          <WeekDayButton
+            key={`${day.shortLabel}-${day.dateLabel}-${index}`}
+            day={day.shortLabel}
+            date={day.dateLabel}
+            isActive={selectedDayIndex === index}
+            isToday={currentDayIndex === index}
+            onPress={() => setSelectedDayIndex(index)}
+          />
+        ))}
+      </XStack>
+
+      {categories.length > 0 && (
+        <CategoryFilter
+          categories={categories}
+          selectedCategory={selectedCategory}
+          onSelectCategory={setSelectedCategory}
+          allLabel={t('mobile.allLessons')}
+          lessonsLabel={t('mobile.lessons')}
+        />
+      )}
+
+      <YStack
+        gap={10}
+        width="100%"
+      >
+        {filteredLessons.length > 0 ? (
+          filteredLessons.map((lesson) => (
+            <MobileLessonCard
+              key={lesson.id}
+              lesson={lesson}
+              joinLabel={t('panels.lessons.upcoming.joinLesson')}
+            />
+          ))
+        ) : (
+          <YStack
+            width="100%"
+            minHeight={config.empty.minHeight}
+            borderWidth={1}
+            borderColor="$myLessonsLessonsEmptyBorder"
+            borderRadius={config.empty.borderRadius}
+            backgroundColor="$myLessonsLessonsEmptyBackground"
+            alignItems="center"
+            justifyContent="center"
+            padding={config.empty.padding}
+          >
+            <Text
+              color="$myLessonsLessonsEmptyDescription"
+              fontSize={config.empty.fontSize}
+              textAlign="center"
+            >
+              {t('mobile.noLessonsForDay')}
+            </Text>
+          </YStack>
+        )}
+      </YStack>
+    </YStack>
+  );
+}

--- a/packages/app/features/home/my-lessons/components/MyLessonsTutorsPanel.tsx
+++ b/packages/app/features/home/my-lessons/components/MyLessonsTutorsPanel.tsx
@@ -1,22 +1,11 @@
 ﻿import { Button, Text, XStack, YStack } from '@mezon-tutors/app/ui';
 import { CompassIcon, StarOutlineIcon } from '@mezon-tutors/app/ui/icons';
 import { ROUTES } from '@mezon-tutors/shared';
+import { DEFAULT_AVATAR_URL } from '@mezon-tutors/shared/src/constants/my-lesson';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { Image, useMedia, useTheme } from 'tamagui';
 import type { TutorItem } from '../types';
-
-function getInitials(name: string): string {
-  const tokens = name.trim().split(/\s+/).filter(Boolean);
-  if (!tokens.length) {
-    return 'NA';
-  }
-
-  return tokens
-    .slice(0, 2)
-    .map((token) => token[0]?.toUpperCase() ?? '')
-    .join('');
-}
 
 function TutorCard({
   tutor,
@@ -26,8 +15,10 @@ function TutorCard({
   onOpenTutor: (tutorId: string) => void;
 }) {
   const t = useTranslations('MyLessons');
+  const media = useMedia();
+  const isMobile = media.sm || media.xs;
   const displayNextLesson = tutor.nextLessonLabel || t('panels.tutors.unscheduled');
-  const avatarUri = tutor.avatar?.trim() || '';
+  const avatarUri = tutor.avatar?.trim() || DEFAULT_AVATAR_URL;
 
   return (
     <XStack
@@ -50,30 +41,13 @@ function TutorCard({
         cursor="pointer"
         onPress={() => onOpenTutor(tutor.id)}
       >
-        {avatarUri ? (
-          <Image
-            source={{ uri: avatarUri }}
-            width={64}
-            height={64}
-            borderRadius={12}
-            accessibilityLabel={tutor.name}
-          />
-        ) : (
-          <YStack
-            width={64}
-            height={64}
-            borderRadius={12}
-            alignItems="center"
-            justifyContent="center"
-            backgroundColor="$myLessonsAvatarBackground"
-            borderWidth={1}
-            borderColor="$myLessonsAvatarBorder"
-          >
-            <Text color="$myLessonsAvatarText" fontSize={20} fontWeight="700">
-              {getInitials(tutor.name)}
-            </Text>
-          </YStack>
-        )}
+        <Image
+          source={{ uri: avatarUri }}
+          width={64}
+          height={64}
+          borderRadius={12}
+          accessibilityLabel={tutor.name}
+        />
 
         <YStack gap={2} flex={1} minWidth={180}>
           <Text color="$myLessonsLessonsPrimaryText" fontSize={22} lineHeight={26} fontWeight="800">
@@ -116,34 +90,70 @@ function TutorCard({
           </Text>
         </XStack>
 
-        <Button
-          variant="primary"
-          backgroundColor="$myLessonsPrimaryButton"
-          borderColor="$myLessonsPrimaryButtonBorder"
-          color="$myLessonsPrimaryButtonText"
-          borderRadius={999}
-          paddingHorizontal="$4"
-          height={34}
-          fontSize={12}
-          fontWeight="700"
-        >
-          {t('panels.tutors.schedule')}
-        </Button>
+        {isMobile ? (
+          <XStack gap="$2" width="100%">
+            <Button
+              variant="primary"
+              backgroundColor="$myLessonsPrimaryButton"
+              borderColor="$myLessonsPrimaryButtonBorder"
+              color="$myLessonsPrimaryButtonText"
+              borderRadius={999}
+              paddingHorizontal="$3"
+              height={34}
+              fontSize={12}
+              fontWeight="700"
+              flex={1}
+            >
+              {t('panels.tutors.schedule')}
+            </Button>
 
-        <Button
-          chromeless
-          backgroundColor="$myLessonsLessonsActionSecondaryBg"
-          borderWidth={1}
-          borderColor="$myLessonsLessonsActionSecondaryBorder"
-          color="$myLessonsLessonsActionSecondaryText"
-          borderRadius={999}
-          paddingHorizontal="$4"
-          height={34}
-          fontSize={12}
-          fontWeight="700"
-        >
-          {t('panels.tutors.message')}
-        </Button>
+            <Button
+              variant="primary"
+              backgroundColor="$myLessonsPrimaryButton"
+              borderColor="$myLessonsPrimaryButtonBorder"
+              color="$myLessonsPrimaryButtonText"
+              borderRadius={999}
+              paddingHorizontal="$3"
+              height={34}
+              fontSize={12}
+              fontWeight="700"
+              flex={1}
+            >
+              {t('panels.tutors.message')}
+            </Button>
+          </XStack>
+        ) : (
+          <>
+            <Button
+              variant="primary"
+              backgroundColor="$myLessonsPrimaryButton"
+              borderColor="$myLessonsPrimaryButtonBorder"
+              color="$myLessonsPrimaryButtonText"
+              borderRadius={999}
+              paddingHorizontal="$4"
+              height={34}
+              fontSize={12}
+              fontWeight="700"
+            >
+              {t('panels.tutors.schedule')}
+            </Button>
+
+            <Button
+              chromeless
+              backgroundColor="$myLessonsLessonsActionSecondaryBg"
+              borderWidth={1}
+              borderColor="$myLessonsLessonsActionSecondaryBorder"
+              color="$myLessonsLessonsActionSecondaryText"
+              borderRadius={999}
+              paddingHorizontal="$4"
+              height={34}
+              fontSize={12}
+              fontWeight="700"
+            >
+              {t('panels.tutors.message')}
+            </Button>
+          </>
+        )}
 
         <Text color="$myLessonsLessonsMutedText" fontSize={18} lineHeight={18} paddingHorizontal={6}>
           ...

--- a/packages/app/features/home/my-lessons/screen.tsx
+++ b/packages/app/features/home/my-lessons/screen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
 import { Screen, ScrollView, Text, YStack } from '@mezon-tutors/app/ui';
@@ -12,9 +12,9 @@ import { MyLessonsHeader } from './components/MyLessonsHeader';
 import { MyLessonsLessonsPanel } from './components/MyLessonsLessonsPanel';
 import { MyLessonsPromoCard } from './components/MyLessonsPromoCard';
 import { MyLessonsTutorsPanel } from './components/MyLessonsTutorsPanel';
-import { getMyLessonsDataByMezonUserId } from './data-source';
+import { MyLessonsMobileCalendar } from './components/MyLessonsMobileCalendar';
 import { useMyLessons } from './hooks/useMyLessons';
-import type { MyLessonsTab, MyLessonsViewData } from './types';
+import type { MyLessonsTab } from './types';
 
 export function MyLessonsScreen() {
   const t = useTranslations('MyLessons');
@@ -27,6 +27,7 @@ export function MyLessonsScreen() {
 
   const media = useMedia();
   const isNarrow = media.md || media.sm || media.xs;
+  const isMobile = media.sm || media.xs;
 
   const handlePrevWeek = () => {
     setSelectedDate((prev) => prev.subtract(7, 'day'));
@@ -49,6 +50,9 @@ export function MyLessonsScreen() {
             paddingHorizontal={isNarrow ? 12 : 28}
             paddingVertical={isNarrow ? 12 : 24}
             gap="$5"
+            $xs={{ paddingHorizontal: 12, paddingVertical: 12, gap: '$3.5' }}
+            $sm={{ paddingHorizontal: 16, paddingVertical: 16, gap: '$4' }}
+            className="my-lessons-screen-container"
           >
             <MyLessonsHeader activeTab={activeTab} onTabChange={setActiveTab} />
 
@@ -70,33 +74,52 @@ export function MyLessonsScreen() {
             ) : null}
 
             {data && activeTab === 'calendar' ? (
-              isNarrow ? (
-                <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-                  <MyLessonsCalendarSection 
-                    calendar={data.calendar} 
-                    lessons={data.calendarLessons}
-                    onPrevWeek={handlePrevWeek}
-                    onNextWeek={handleNextWeek}
-                  />
-                </ScrollView>
-              ) : (
-                <MyLessonsCalendarSection 
+              isMobile ? (
+                <MyLessonsMobileCalendar 
                   calendar={data.calendar} 
                   lessons={data.calendarLessons}
                   onPrevWeek={handlePrevWeek}
                   onNextWeek={handleNextWeek}
                 />
+              ) : (
+                <YStack gap="$5" width="100%" maxWidth={1032} alignSelf="center">
+                  <MyLessonsPromoCard />
+                  {isNarrow ? (
+                    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                      <MyLessonsCalendarSection 
+                        calendar={data.calendar} 
+                        lessons={data.calendarLessons}
+                        onPrevWeek={handlePrevWeek}
+                        onNextWeek={handleNextWeek}
+                      />
+                    </ScrollView>
+                  ) : (
+                    <MyLessonsCalendarSection 
+                      calendar={data.calendar} 
+                      lessons={data.calendarLessons}
+                      onPrevWeek={handlePrevWeek}
+                      onNextWeek={handleNextWeek}
+                    />
+                  )}
+                </YStack>
               )
             ) : null}
 
             {data && activeTab === 'lessons' ? (
-              <YStack gap="$5" width="100%" maxWidth={1032} alignSelf="center">
-                <MyLessonsPromoCard />
+              isMobile ? (
                 <MyLessonsLessonsPanel
                   upcomingLessons={data.upcomingLessons}
                   previousLessons={data.previousLessons}
                 />
-              </YStack>
+              ) : (
+                <YStack gap="$5" width="100%" maxWidth={1032} alignSelf="center">
+                  <MyLessonsPromoCard />
+                  <MyLessonsLessonsPanel
+                    upcomingLessons={data.upcomingLessons}
+                    previousLessons={data.previousLessons}
+                  />
+                </YStack>
+              )
             ) : null}
 
             {data && activeTab === 'tutors' ? <MyLessonsTutorsPanel tutors={data.tutors} /> : null}

--- a/packages/app/services/availability.service.ts
+++ b/packages/app/services/availability.service.ts
@@ -37,7 +37,7 @@ export const availabilityService = {
     const availability: AvailabilitySlot[] = [];
     
     Object.entries(data.slotsByDay).forEach(([dayKey, slots]) => {
-      const dayIndex = DAY_KEYS.indexOf(dayKey);
+      const dayIndex = DAY_KEYS.indexOf(dayKey as typeof DAY_KEYS[number]);
       const dayOfWeek = dayIndex === 6 ? 0 : dayIndex + 1;
       
       slots.forEach(slot => {

--- a/packages/app/ui/icons/ChevronLeftIcon.tsx
+++ b/packages/app/ui/icons/ChevronLeftIcon.tsx
@@ -1,0 +1,19 @@
+import Svg, { Path } from 'react-native-svg';
+import { IconProps } from './types';
+
+export const ChevronLeftIcon = ({ size = 24, width, height, color, ...props }: IconProps) => {
+  return (
+    <Svg
+      width={width ?? size}
+      height={height ?? size}
+      viewBox="0 0 24 24"
+      fill="none"
+      {...props}
+    >
+      <Path
+        d="M15.41 7.41L14 6L8 12L14 18L15.41 16.59L10.83 12L15.41 7.41Z"
+        fill={color ?? '#7F93BD'}
+      />
+    </Svg>
+  );
+};

--- a/packages/app/ui/icons/ChevronRightIcon.tsx
+++ b/packages/app/ui/icons/ChevronRightIcon.tsx
@@ -1,0 +1,19 @@
+import Svg, { Path } from 'react-native-svg';
+import { IconProps } from './types';
+
+export const ChevronRightIcon = ({ size = 24, width, height, color, ...props }: IconProps) => {
+  return (
+    <Svg
+      width={width ?? size}
+      height={height ?? size}
+      viewBox="0 0 24 24"
+      fill="none"
+      {...props}
+    >
+      <Path
+        d="M8.59 16.59L10 18L16 12L10 6L8.59 7.41L13.17 12L8.59 16.59Z"
+        fill={color ?? '#7F93BD'}
+      />
+    </Svg>
+  );
+};

--- a/packages/app/ui/icons/MenuIcon.tsx
+++ b/packages/app/ui/icons/MenuIcon.tsx
@@ -1,0 +1,20 @@
+import Svg, { Path } from 'react-native-svg'
+
+type MenuIconProps = {
+  size?: number
+  color?: string
+}
+
+export function MenuIcon({ size = 24, color = '#111827' }: MenuIconProps) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M3 12h18M3 6h18M3 18h18"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  )
+}

--- a/packages/app/ui/icons/index.ts
+++ b/packages/app/ui/icons/index.ts
@@ -7,6 +7,8 @@ export * from './CameraIcon';
 export * from './CardIcon';
 export * from './BookingRequestIcon';
 export * from './CheckIcon';
+export * from './ChevronLeftIcon';
+export * from './ChevronRightIcon';
 export * from './CircleCheckIcon';
 export * from './CircleCloseIcon';
 export * from './ClockCircleIcon';
@@ -52,6 +54,7 @@ export * from './LanguageIcon'
 export * from './StarOutlineIcon'
 export * from './LogoutIcon'
 export * from './LogoIcon'
+export * from './MenuIcon'
 export * from './FeatureEveningClassesIcon'
 export * from './FeatureFlexibleWeekendsIcon'
 export * from './FeatureLearnViaMezonIcon'

--- a/packages/shared/locales/en/my-lessons.json
+++ b/packages/shared/locales/en/my-lessons.json
@@ -67,5 +67,10 @@
   "screen": {
     "loading": "Loading lessons data..."
   },
+  "mobile": {
+    "allLessons": "All",
+    "lessons": "Lessons",
+    "noLessonsForDay": "No lessons scheduled for this day"
+  },
   "previewFooter": "TutorMatch interface preview."
 }

--- a/packages/shared/locales/vi/my-lessons.json
+++ b/packages/shared/locales/vi/my-lessons.json
@@ -9,7 +9,7 @@
     "avatarAlt": "Ảnh đại diện người dùng đã đăng nhập"
   },
   "header": {
-    "title": "Lớp học của tôi",
+    "title": "Lịch học của tôi",
     "scheduleLesson": "+ Đặt lịch học",
     "tabs": {
       "lessons": "Buổi học",
@@ -66,6 +66,11 @@
   },
   "screen": {
     "loading": "Đang tải dữ liệu buổi học..."
+  },
+  "mobile": {
+    "allLessons": "Tất cả",
+    "lessons": "Buổi học",
+    "noLessonsForDay": "Không có buổi học nào trong ngày này"
   },
   "previewFooter": "Xem trước giao diện TutorMatch."
 }

--- a/packages/shared/src/constants/dashboard.ts
+++ b/packages/shared/src/constants/dashboard.ts
@@ -1,17 +1,10 @@
 import { ROUTES } from './routes';
 
-export type DashboardMenuIconKey =
-  | 'document'
-  | 'bookingRequests'
-  | 'calendar'
-  | 'logout';
-export type DashboardMenuLabelKey =
-  | 'myLessons'
-  | 'bookingRequests'
-  | 'mySchedule'
-  | 'logout';
+export type DashboardMenuIconKey = 'document' | 'bookingRequests' | 'calendar' | 'logout';
+export type DashboardMenuLabelKey = 'myLessons' | 'bookingRequests' | 'mySchedule' | 'logout';
 
-export type DashboardRole = 'STUDENT' | 'TUTOR';
+export const DASHBOARD_ROLES = ['STUDENT', 'TUTOR'] as const;
+export type DashboardRole = (typeof DASHBOARD_ROLES)[number];
 
 export type DashboardMenuItem = {
   key: string;
@@ -55,3 +48,42 @@ export const DASHBOARD_MENU_ITEMS: DashboardMenuItem[] = [
     roles: ['STUDENT', 'TUTOR'],
   },
 ];
+
+export function isDashboardRole(role: string | null | undefined): role is DashboardRole {
+  if (!role) {
+    return false;
+  }
+
+  return DASHBOARD_ROLES.includes(role as DashboardRole);
+}
+
+export function getDashboardMenuItemsByRole(role: string | null | undefined): DashboardMenuItem[] {
+  if (!isDashboardRole(role)) {
+    return [];
+  }
+
+  return DASHBOARD_MENU_ITEMS.filter((item) => item.roles.includes(role));
+}
+
+export const DASHBOARD_SIDEBAR_CONFIG = {
+  width: 240,
+  padding: {
+    container: 16,
+    item: {
+      vertical: 8,
+      horizontal: 12,
+    },
+  },
+  borderRadius: 12,
+  iconSizes: {
+    default: 16,
+    bookingRequests: 19,
+  },
+} as const;
+
+export const DASHBOARD_ICON_MAP = {
+  document: 'DocumentIcon',
+  bookingRequests: 'BookingRequestIcon',
+  calendar: 'CalendarIcon',
+  logout: 'LogoutIcon',
+} as const;

--- a/packages/shared/src/constants/header.ts
+++ b/packages/shared/src/constants/header.ts
@@ -10,3 +10,87 @@ export const HEADER_LOCALES = [
   { code: 'en', label: 'EN' },
   { code: 'vi', label: 'VI' },
 ] as const;
+
+export const HEADER_CONFIG = {
+  height: {
+    desktop: 80,
+    tablet: 60,
+    mobile: 56,
+  },
+  padding: {
+    desktop: 60,
+    tablet: 14,
+    mobile: 12,
+  },
+  logo: {
+    size: 24,
+    fontSize: 18,
+    lineHeight: 24,
+    mobileDashboardFontSize: 18,
+    borderRadius: 999,
+    padding: {
+      vertical: 6,
+      horizontal: 10,
+    },
+    mobilePadding: {
+      vertical: 6,
+      horizontal: 6,
+    },
+  },
+  avatar: {
+    size: {
+      desktop: 36,
+      tablet: 32,
+      mobile: 28,
+    },
+    borderWidth: 2,
+    padding: {
+      desktop: 4,
+      tablet: 3,
+      mobile: 2,
+    },
+  },
+  nav: {
+    gap: {
+      desktop: 30,
+      tablet: 10,
+      mobile: 8,
+    },
+    fontSize: {
+      desktop: 14,
+      tablet: 13,
+      mobile: 12,
+    },
+  },
+  menu: {
+    iconSize: 24,
+    buttonPadding: 2,
+    buttonBorderRadius: 8,
+    dashboardGap: 4,
+  },
+  drawer: {
+    width: 240,
+    logoSize: 32,
+    logoFontSize: 20,
+    padding: 16,
+    itemGap: 12,
+    itemBorderRadius: 12,
+    itemPadding: {
+      vertical: 8,
+      horizontal: 12,
+    },
+    iconSize: {
+      default: 16,
+      bookingRequests: 19,
+    },
+  },
+  transition: {
+    duration: '420ms',
+    easing: 'cubic-bezier(0.22,1,0.36,1)',
+    borderDuration: '320ms',
+  },
+  backdrop: {
+    blur: 'blur(14px) saturate(140%)',
+    overlayOpacity: 0.5,
+  },
+} as const;

--- a/packages/shared/src/constants/my-lesson.ts
+++ b/packages/shared/src/constants/my-lesson.ts
@@ -1,0 +1,69 @@
+export const DEFAULT_AVATAR_URL = 'https://api.dicebear.com/7.x/avataaars/svg?seed=default';
+
+export const MY_LESSONS_MOBILE_CONFIG = {
+  weekDay: {
+    minWidth: 44,
+    maxWidth: 44,
+    width: 44,
+    padding: {
+      vertical: 14,
+      horizontal: 4,
+    },
+    borderRadius: 12,
+    dayFontSize: 9,
+    dayLineHeight: 10,
+    dateFontSize: 15,
+    dateLineHeight: 18,
+  },
+  card: {
+    borderRadius: 10,
+    padding: 10,
+    gap: 8,
+    avatar: {
+      size: 40,
+      borderRadius: 999,
+    },
+    subject: {
+      fontSize: 13,
+      lineHeight: 16,
+    },
+    tutor: {
+      fontSize: 11,
+      lineHeight: 14,
+    },
+    time: {
+      fontSize: 10,
+      lineHeight: 14,
+      iconSize: 11,
+    },
+    button: {
+      fontSize: 11,
+      borderRadius: 7,
+      padding: {
+        vertical: 7,
+        horizontal: 12,
+      },
+    },
+  },
+  category: {
+    dotSize: 6,
+    fontSize: 11,
+    padding: {
+      horizontal: 10,
+      vertical: 4,
+    },
+    borderRadius: 16,
+  },
+  navigation: {
+    iconSize: 16,
+    buttonPadding: 4,
+    buttonBorderRadius: 6,
+    titleFontSize: 13,
+  },
+  empty: {
+    minHeight: 120,
+    borderRadius: 10,
+    padding: 12,
+    fontSize: 11,
+  },
+} as const;

--- a/packages/shared/src/constants/my-lesson.ts
+++ b/packages/shared/src/constants/my-lesson.ts
@@ -6,14 +6,15 @@ export const MY_LESSONS_MOBILE_CONFIG = {
     maxWidth: 44,
     width: 44,
     padding: {
-      vertical: 14,
+      vertical: 26,
       horizontal: 4,
     },
+    contentGap: 0,
     borderRadius: 12,
     dayFontSize: 9,
-    dayLineHeight: 10,
+    dayLineHeight:9,
     dateFontSize: 15,
-    dateLineHeight: 18,
+    dateLineHeight: 9,
   },
   card: {
     borderRadius: 10,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -34,6 +34,7 @@ export * from './constants/dashboard';
 export * from './constants/dashboard-booking-request';
 export * from './constants/payment';
 export * from './constants/my-schedule';
+export * from './constants/my-lesson';
 export * from './constants/cloudinary';
 
 export * from './constants/review';


### PR DESCRIPTION
# Mobile Responsive - My Lessons Page

## Changes
- Built a dedicated mobile calendar UI with weekly navigation and day selection.
- Added a horizontal, scrollable category filter for quick lesson filtering.
- Hid desktop-only elements on mobile (Dashboard sidebar and PromoCard).
- Optimized the My Lessons header for small screens (compact title + action button).
- Added locale-aware calendar formatting (weekday labels and month title via i18n).

## Refactor
- Extracted shared dashboard menu rendering into a reusable `DashboardMenuList`.
- Reduced duplication between `DashboardSidebar` and `DashboardMobileDrawer`.
- Centralized dashboard menu role filtering with shared helpers (`getDashboardMenuItemsByRole`).


<img width="405" height="766" alt="image" src="https://github.com/user-attachments/assets/2d4afe1a-6e88-4e42-80f4-40932343dd64" />

<img width="393" height="662" alt="image" src="https://github.com/user-attachments/assets/bc4489e7-834a-40f2-a254-3db85f77884e" />
<img width="395" height="731" alt="image" src="https://github.com/user-attachments/assets/0ff2caa1-af40-4d19-84b6-3bfacc5101cb" />

<img width="415" height="713" alt="image" src="https://github.com/user-attachments/assets/89e0d60c-5656-4507-8316-c800dca158ad" />
<img width="396" height="765" alt="image" src="https://github.com/user-attachments/assets/addd75af-79d6-4544-ab65-dd4558c242e5" />
<img width="413" height="769" alt="image" src="https://github.com/user-attachments/assets/5e5612a1-8917-470e-8fbd-a20641c2b093" />