### PR TITLE
Fix/show correct time slot and day collumn in trial booking

### DIFF
--- a/apps/api/src/modules/my-lessons/my-lessons.service.ts
+++ b/apps/api/src/modules/my-lessons/my-lessons.service.ts
@@ -122,15 +122,26 @@ export class MyLessonsService {
       weekStartDate,
       timezoneName
     );
-    const calendarLessons = calendarTrialRows
-      .map((lesson) => this.toLessonCalendarApiItem(lesson, timezoneName))
-      .filter((item): item is MyLessonApiItem => item !== null);
+    const weekStartResolved = weekStartDate
+      ? this.parseWeekStartMondayYmd(weekStartDate, timezoneName)
+      : dayjs(this.getWeekStart(calendarBaseDate, timezoneName)).tz(timezoneName).startOf('day');
+    const weekStartDateObj = weekStartResolved.toDate();
+    const weekYmd = weekStartResolved.format('YYYY-MM-DD');
 
-    const weekYmd =
-      weekStartDate ??
-      dayjs(this.getWeekStart(calendarBaseDate, timezoneName))
-        .tz(timezoneName)
-        .format('YYYY-MM-DD');
+    const calendarLessons = calendarTrialRows
+      .map((lesson) => {
+        const item = this.toLessonCalendarApiItem(lesson, timezoneName);
+        if (!item) {
+          return null;
+        }
+        return this.withCalendarColumnIndex(
+          item,
+          lesson.startAt,
+          weekStartDateObj,
+          timezoneName
+        );
+      })
+      .filter((item): item is MyLessonApiItem => item !== null);
 
     const enrollments = await this.prisma.subscriptionEnrollment.findMany({
       where: {
@@ -170,12 +181,17 @@ export class MyLessonsService {
         if (!calendarStatus) {
           continue;
         }
-        const item = this.enrollmentOccurrenceToLessonItem(
-          enrollment,
+        const item = this.withCalendarColumnIndex(
+          this.enrollmentOccurrenceToLessonItem(
+            enrollment,
+            range.startAt,
+            range.endAt,
+            occ.slotIndex,
+            calendarStatus,
+            timezoneName
+          ),
           range.startAt,
-          range.endAt,
-          occ.slotIndex,
-          calendarStatus,
+          weekStartDateObj,
           timezoneName
         );
         subscriptionCalendarItems.push(item);
@@ -475,9 +491,34 @@ export class MyLessonsService {
     return `${this.formatTime(start, timezoneName)} - ${this.formatTime(end, timezoneName)}`;
   }
 
+  /** Monday=0 … Sunday=6 for the calendar week containing `date` (wall clock in TZ). */
   private toCalendarDayIndex(date: Date, timezoneName: string): number {
     const dow = dayjs(date).tz(timezoneName).day();
     return dow === 0 ? 6 : dow - 1;
+  }
+
+  /** Column index 0–6 = offset from `weekStart` (must match `week_days` headers). */
+  private toCalendarColumnIndex(
+    date: Date,
+    weekStart: Date,
+    timezoneName: string
+  ): number {
+    const start = dayjs(weekStart).tz(timezoneName).startOf('day');
+    const eventDay = dayjs(date).tz(timezoneName).startOf('day');
+    const diff = eventDay.diff(start, 'day');
+    return Math.max(0, Math.min(6, diff));
+  }
+
+  private withCalendarColumnIndex(
+    item: MyLessonApiItem,
+    startAt: Date,
+    weekStart: Date,
+    timezoneName: string
+  ): MyLessonApiItem {
+    return {
+      ...item,
+      day_index: this.toCalendarColumnIndex(startAt, weekStart, timezoneName),
+    };
   }
 
   private normalizeAvailabilityDay(dayOfWeek: number): number {
@@ -502,10 +543,7 @@ export class MyLessonsService {
     timezoneName = DEFAULT_CALENDAR_TZ
   ): Date {
     if (weekStartDate) {
-      const parsed = dayjs(weekStartDate).tz(timezoneName).startOf('day');
-      if (parsed.isValid()) {
-        return parsed.toDate();
-      }
+      return this.parseWeekStartMondayYmd(weekStartDate, timezoneName).toDate();
     }
 
     return dayjs().tz(timezoneName).toDate();
@@ -521,9 +559,9 @@ export class MyLessonsService {
     let weekEnd: Date;
 
     if (weekStartDate) {
-      const parsed = dayjs(weekStartDate).tz(timezoneName).startOf('day');
-      weekStart = parsed.toDate();
-      weekEnd = parsed.add(7, 'day').toDate();
+      const monday = this.parseWeekStartMondayYmd(weekStartDate, timezoneName);
+      weekStart = monday.toDate();
+      weekEnd = monday.add(7, 'day').toDate();
     } else {
       weekStart = this.getWeekStart(baseDate, timezoneName);
       weekEnd = dayjs(weekStart).add(7, 'day').toDate();
@@ -549,14 +587,15 @@ export class MyLessonsService {
     let weekDays: MyLessonWeekDayApiItem[];
 
     if (weekStartDate) {
-      const parsed = dayjs(weekStartDate).tz(timezoneName).startOf('day');
-      weekStart = parsed.toDate();
+      const monday = this.parseWeekStartMondayYmd(weekStartDate, timezoneName);
+      weekStart = monday.toDate();
 
       weekDays = Array.from({ length: 7 }, (_, index) => {
-        const day = parsed.add(index, 'day');
+        const day = monday.add(index, 'day');
         return {
           short_label: day.format('ddd'),
           date_label: day.format('DD'),
+          date_ymd: day.format('YYYY-MM-DD'),
         };
       });
     } else {
@@ -581,7 +620,7 @@ export class MyLessonsService {
     const weekStartMs = weekStart.getTime();
     const isCurrentWeek = nowMs >= weekStartMs && nowMs < weekEndMs;
     const currentDayIndex = isCurrentWeek
-      ? this.toCalendarDayIndex(now.toDate(), timezoneName)
+      ? this.toCalendarColumnIndex(now.toDate(), weekStart, timezoneName)
       : undefined;
 
     return {
@@ -593,6 +632,16 @@ export class MyLessonsService {
     };
   }
 
+  private parseWeekStartMondayYmd(weekStartYmd: string, timezoneName: string) {
+    const parsed = dayjs.tz(weekStartYmd, 'YYYY-MM-DD', timezoneName).startOf('day');
+    if (!parsed.isValid()) {
+      return dayjs().tz(timezoneName).startOf('day');
+    }
+    const jsDay = parsed.day();
+    const mondayOffset = jsDay === 0 ? 6 : jsDay - 1;
+    return parsed.subtract(mondayOffset, 'day');
+  }
+
   private getWeekStart(date: Date, timezoneName: string): Date {
     const d = dayjs(date).tz(timezoneName).startOf('day');
     const idx = this.toCalendarDayIndex(date, timezoneName);
@@ -600,12 +649,14 @@ export class MyLessonsService {
   }
 
   private buildWeekDays(weekStart: Date, timezoneName: string): MyLessonWeekDayApiItem[] {
+    const monday = dayjs(weekStart).tz(timezoneName).startOf('day');
     return Array.from({ length: 7 }, (_, index) => {
-      const day = dayjs(weekStart).tz(timezoneName).add(index, 'day');
+      const day = monday.add(index, 'day');
 
       return {
         short_label: day.format('ddd'),
         date_label: day.format('DD'),
+        date_ymd: day.format('YYYY-MM-DD'),
       };
     });
   }

--- a/apps/api/src/modules/my-lessons/my-lessons.service.ts
+++ b/apps/api/src/modules/my-lessons/my-lessons.service.ts
@@ -244,7 +244,7 @@ export class MyLessonsService {
       calendar_lessons: mergedCalendar,
       upcoming_lessons: mergedUpcoming,
       previous_lessons: mergedPrevious,
-      tutors: this.buildTutorItems(lessons),
+      tutors: this.buildTutorItems(lessons, timezoneName),
     };
   }
 
@@ -355,7 +355,10 @@ export class MyLessonsService {
     };
   }
 
-  private buildTutorItems(lessons: TrialLessonBookingWithTutor[]): MyLessonTutorApiItem[] {
+  private buildTutorItems(
+    lessons: TrialLessonBookingWithTutor[],
+    timezoneName: string
+  ): MyLessonTutorApiItem[] {
     const tutorMap = new Map<
       string,
       {
@@ -417,8 +420,9 @@ export class MyLessonsService {
         availability: tutor.availability,
         completed_lessons: tutor.completedLessons,
         next_lesson_label: tutor.nextLessonAt
-          ? this.toUtc(tutor.nextLessonAt).format('ddd, h:mm A')
+          ? dayjs(tutor.nextLessonAt).tz(timezoneName).format('ddd, h:mm A')
           : '',
+        next_lesson_at: tutor.nextLessonAt ? tutor.nextLessonAt.toISOString() : null,
         rating_average: tutor.ratingAverage,
         review_count: tutor.reviewCount,
       }))

--- a/apps/api/src/modules/my-schedule/my-schedule.service.ts
+++ b/apps/api/src/modules/my-schedule/my-schedule.service.ts
@@ -142,7 +142,10 @@ export class MyScheduleService {
     const trialLessonEvents: ScheduleEvent[] = bookings.map((booking) => {
       const startsAt = dayjs(booking.startAt).tz(timezoneName);
       const endsAt = startsAt.add(booking.durationMinutes, 'minute');
-      const dayIndex = startsAt.day() === 0 ? 6 : startsAt.day() - 1;
+      const dayIndex = Math.max(
+        0,
+        Math.min(6, startsAt.startOf('day').diff(monday.startOf('day'), 'day'))
+      );
 
       let status: 'upcoming' | 'pending' | 'blocked';
       if (booking.status === ETrialLessonStatus.CANCELLED) {
@@ -180,7 +183,10 @@ export class MyScheduleService {
         return subscriptionSlotsOccurrencesForWeek(weekStartYmd, slots, timezoneName).map((occ) => {
           const startsAt = dayjs(occ.startAt).tz(timezoneName);
           const endsAt = startsAt.add(slots[occ.slotIndex]?.durationMinutes ?? 60, 'minute');
-          const dayIndex = startsAt.day() === 0 ? 6 : startsAt.day() - 1;
+          const dayIndex = Math.max(
+            0,
+            Math.min(6, startsAt.startOf('day').diff(monday.startOf('day'), 'day'))
+          );
           return {
             id: `sub-${enrollment.id}-${occ.slotIndex}`,
             dayIndex,

--- a/apps/web/src/components/calendar/utils/calendar-utils.ts
+++ b/apps/web/src/components/calendar/utils/calendar-utils.ts
@@ -123,16 +123,18 @@ export function buildRowModels(
       index += 1;
     }
 
-    const emptyCount = index - startIndex;
+    const emptySlotCount = index - startIndex;
 
-    if (emptyCount >= minGapHours) {
+    if (emptySlotCount >= minGapHours) {
       const startHour = sortedHours[startIndex];
       const lastEmptyHour = sortedHours[index - 1] ?? startHour;
+      const endHour = Math.min(24, lastEmptyHour + 1);
       rows.push({
         type: 'gap',
         startHour,
-        endHour: Math.min(24, lastEmptyHour + 1),
-        hourCount: emptyCount,
+        endHour,
+        /** Wall-clock span (matches formatRangeLabel), not discrete weekHours indices (0–24 ⇒ 25 ticks). */
+        hourCount: endHour - startHour,
       });
     } else {
       for (let i = startIndex; i < index; i++) {

--- a/apps/web/src/components/calendar/utils/format-locale.ts
+++ b/apps/web/src/components/calendar/utils/format-locale.ts
@@ -50,7 +50,19 @@ export function formatLessonDateLabel(dateLabel: string, locale: string): string
   return dateLabel;
 }
 
-export function formatTutorNextLessonLabel(nextLessonLabel: string, locale: string): string {
+export function formatTutorNextLessonLabel(
+  nextLessonLabel: string,
+  locale: string,
+  timezoneName?: string,
+  nextLessonAtIso?: string | null,
+): string {
+  if (nextLessonAtIso && timezoneName) {
+    const instant = dayjs(nextLessonAtIso);
+    if (instant.isValid()) {
+      return instant.tz(timezoneName).locale(locale).format('ddd, h:mm A');
+    }
+  }
+
   const date = dayjs(nextLessonLabel, 'ddd, h:mm A', 'en', true);
   if (date.isValid()) {
     return date.locale(locale).format('ddd, h:mm A');

--- a/apps/web/src/components/calendar/utils/format-locale.ts
+++ b/apps/web/src/components/calendar/utils/format-locale.ts
@@ -14,23 +14,29 @@ export function formatCalendarTitle(title: string, locale: string): string {
   return date.isValid() ? date.format('MMMM YYYY') : title;
 }
 
-export function formatWeekDays(weekDays: CalendarWeekDay[], locale: string): CalendarWeekDay[] {
-  return weekDays.map((day, index) => {
-    let dayDate: dayjs.Dayjs;
-    
-    if (day.fullDate) {
-      dayDate = dayjs(day.fullDate).locale(locale);
-    } else {
-      const now = dayjs();
-      const dayOfWeek = now.day();
-      const mondayOffset = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
-      const monday = now.subtract(mondayOffset, 'day');
-      dayDate = monday.add(index, 'day').locale(locale);
+export function formatWeekDays(
+  weekDays: CalendarWeekDay[],
+  locale: string,
+  timezoneName?: string,
+): CalendarWeekDay[] {
+  return weekDays.map((day) => {
+    if (!day.fullDate) {
+      return {
+        shortLabel: day.shortLabel,
+        dateLabel: day.dateLabel,
+        fullDate: day.fullDate,
+      };
     }
-    
+
+    const dayDate = (timezoneName
+      ? dayjs(day.fullDate).tz(timezoneName)
+      : dayjs(day.fullDate)
+    ).locale(locale);
+
     return {
       shortLabel: dayDate.format('ddd').toUpperCase(),
-      dateLabel: day.dateLabel,
+      dateLabel: dayDate.format('DD'),
+      fullDate: day.fullDate,
     };
   });
 }

--- a/apps/web/src/components/common/ScheduleViewer.tsx
+++ b/apps/web/src/components/common/ScheduleViewer.tsx
@@ -23,6 +23,7 @@ const DAY_COUNT = CALENDAR_CONFIG.DAYS_PER_WEEK;
 const MINUTES_PER_DAY = 24 * 60;
 const DEFAULT_TIMEZONE = 'UTC';
 
+/** Wall-clock slot in `timezone` (YYYY-MM-DD + HH:mm), not UTC. */
 export type ScheduleSlotInput = {
   date: string;
   startTime: string;
@@ -30,8 +31,10 @@ export type ScheduleSlotInput = {
 };
 
 export interface ScheduleViewerProps {
+  /** Slots expanded for the viewer; use `utcWeeklySlotsToCalendarInstances` when DB stores UTC weekly rows. */
   availableSlots: ScheduleSlotInput[];
   className?: string;
+  /** IANA timezone used for week headers and cell timestamps (typically `useUserTimezone()`). */
   timezone?: string;
 }
 

--- a/apps/web/src/services/my-lessons/my-lessons.api.ts
+++ b/apps/web/src/services/my-lessons/my-lessons.api.ts
@@ -12,7 +12,11 @@ import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { useAtomValue } from "jotai";
-import { detectBrowserTimezone, resolveUserTimezone } from "@/lib/timezone";
+import {
+  detectBrowserTimezone,
+  parseYmdInTimezone,
+  resolveUserTimezone,
+} from "@/lib/timezone";
 import { isAuthenticatedAtom, userAtom } from "@/store";
 import { apiClient } from "../api-client";
 import { myLessonsQueryKey } from "./my-lessons.qkey";
@@ -33,6 +37,7 @@ export type LessonStatus = "upcoming" | "completed";
 export type WeekDay = {
   shortLabel: string;
   dateLabel: string;
+  fullDate?: Date;
 };
 
 export type LessonItem = {
@@ -95,9 +100,15 @@ const mapCategory = (category: MyLessonApiCategory): LessonCategory => {
 const mapStatus = (status: MyLessonApiStatus): LessonStatus =>
   status === MyLessonsStatusEnum.Upcoming ? "upcoming" : "completed";
 
-const mapWeekDay = (item: MyLessonWeekDayApiItem): WeekDay => ({
+const mapWeekDay = (
+  item: MyLessonWeekDayApiItem,
+  timezoneName: string,
+): WeekDay => ({
   shortLabel: item.short_label,
   dateLabel: item.date_label,
+  fullDate: item.date_ymd
+    ? parseYmdInTimezone(item.date_ymd, timezoneName).toDate()
+    : undefined,
 });
 
 const roundToHalfHour = (hour: number): number => {
@@ -148,6 +159,7 @@ const mapTutor = (item: MyLessonTutorApiItem): TutorItem => ({
 const mapCalendarMeta = (
   data: MyLessonsApiResponse,
   lessons: LessonItem[],
+  timezoneName: string,
 ): MyLessonsCalendarMeta => {
   const { MIN, MAX } = CALENDAR_CONFIG.DEFAULT_VISIBLE_RANGE;
 
@@ -171,7 +183,7 @@ const mapCalendarMeta = (
 
   return {
     title: data.calendar_title,
-    weekDays: data.week_days.map(mapWeekDay),
+    weekDays: data.week_days.map((day) => mapWeekDay(day, timezoneName)),
     weekHours,
     currentDayIndex: data.current_day_index,
     currentHour,
@@ -197,7 +209,7 @@ export const myLessonsApi = {
     const calendarLessons = data.calendar_lessons.map(mapLesson);
 
     return {
-      calendar: mapCalendarMeta(data, calendarLessons),
+      calendar: mapCalendarMeta(data, calendarLessons, timezoneName ?? "UTC"),
       calendarLessons,
       upcomingLessons: data.upcoming_lessons.map(mapLesson),
       previousLessons: data.previous_lessons.map(mapLesson),

--- a/apps/web/src/services/my-lessons/my-lessons.api.ts
+++ b/apps/web/src/services/my-lessons/my-lessons.api.ts
@@ -67,6 +67,7 @@ export type TutorItem = {
   availability: string;
   completedLessons: number;
   nextLessonLabel: string;
+  nextLessonAt?: string | null;
   ratingAverage: number;
   reviewCount: number;
 };
@@ -152,6 +153,7 @@ const mapTutor = (item: MyLessonTutorApiItem): TutorItem => ({
   availability: item.availability,
   completedLessons: item.completed_lessons,
   nextLessonLabel: item.next_lesson_label,
+  nextLessonAt: item.next_lesson_at ?? null,
   ratingAverage: item.rating_average,
   reviewCount: item.review_count,
 });

--- a/apps/web/src/views/main/my-lessons/components/MyLessonsCalendarCard.tsx
+++ b/apps/web/src/views/main/my-lessons/components/MyLessonsCalendarCard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { formatCalendarTitle, formatWeekDays } from '@/components/calendar';
+import { formatCalendarTitle } from '@/components/calendar';
 import { DashboardScheduleCalendar } from '@/components/schedule';
-import { buildFallbackWeekDays, ROUTES } from '@mezon-tutors/shared';
+import { ROUTES } from '@mezon-tutors/shared';
+import { parseYmdInTimezone } from '@/lib/timezone';
 import { useLocale, useTranslations } from 'next-intl';
 import type { LessonItem, MyLessonsCalendarMeta } from '@/services';
 import { userAtom } from '@/store/auth.atom';
@@ -15,6 +16,8 @@ import { useAtomValue } from 'jotai';
 type MyLessonsCalendarCardProps = {
   lessons: LessonItem[];
   calendar: MyLessonsCalendarMeta;
+  weekStartYmd: string;
+  timezoneName: string;
   onPrevWeek?: () => void;
   onNextWeek?: () => void;
   onGoToToday?: () => void;
@@ -24,6 +27,8 @@ type MyLessonsCalendarCardProps = {
 export default function MyLessonsCalendarCard({
   lessons,
   calendar,
+  weekStartYmd,
+  timezoneName,
   onPrevWeek,
   onNextWeek,
   onGoToToday,
@@ -40,14 +45,17 @@ export default function MyLessonsCalendarCard({
 
   const formattedTitle = formatCalendarTitle(calendar.title, locale);
 
-  const displayWeekDays = useMemo(
-    () =>
-      formatWeekDays(
-        calendar.weekDays.length ? calendar.weekDays : buildFallbackWeekDays(),
-        locale,
-      ),
-    [calendar.weekDays, locale],
-  );
+  const displayWeekDays = useMemo(() => {
+    const monday = parseYmdInTimezone(weekStartYmd, timezoneName);
+    return Array.from({ length: 7 }, (_, index) => {
+      const day = monday.add(index, 'day').locale(locale);
+      return {
+        shortLabel: day.format('ddd').toUpperCase(),
+        dateLabel: day.format('DD'),
+        fullDate: day.toDate(),
+      };
+    });
+  }, [weekStartYmd, timezoneName, locale]);
 
   const lessonModalDetailRows = useMemo(() => {
     if (!pickedLesson) return undefined;

--- a/apps/web/src/views/main/my-lessons/components/MyLessonsCalendarSection.tsx
+++ b/apps/web/src/views/main/my-lessons/components/MyLessonsCalendarSection.tsx
@@ -6,6 +6,8 @@ import MyLessonsCalendarCard from './MyLessonsCalendarCard';
 type MyLessonsCalendarSectionProps = {
   calendar: MyLessonsCalendarMeta;
   lessons: LessonItem[];
+  weekStartYmd: string;
+  timezoneName: string;
   onPrevWeek?: () => void;
   onNextWeek?: () => void;
   onGoToToday?: () => void;
@@ -15,6 +17,8 @@ type MyLessonsCalendarSectionProps = {
 export default function MyLessonsCalendarSection({
   calendar,
   lessons,
+  weekStartYmd,
+  timezoneName,
   onPrevWeek,
   onNextWeek,
   onGoToToday,
@@ -24,6 +28,8 @@ export default function MyLessonsCalendarSection({
     <MyLessonsCalendarCard
       lessons={lessons}
       calendar={calendar}
+      weekStartYmd={weekStartYmd}
+      timezoneName={timezoneName}
       onPrevWeek={onPrevWeek}
       onNextWeek={onNextWeek}
       onGoToToday={onGoToToday}

--- a/apps/web/src/views/main/my-lessons/components/MyTutorsPanel.tsx
+++ b/apps/web/src/views/main/my-lessons/components/MyTutorsPanel.tsx
@@ -16,6 +16,7 @@ import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { Button } from "@/components/ui";
 import { formatTutorNextLessonLabel } from "@/components/calendar/utils/format-locale";
+import { useUserTimezone } from "@/hooks";
 import type { TutorItem } from "@/services/my-lessons/my-lessons.api";
 
 type TutorCardProps = {
@@ -26,9 +27,17 @@ type TutorCardProps = {
 function TutorCard({ tutor, onOpenTutor }: TutorCardProps) {
   const t = useTranslations("MyLessons");
   const locale = useLocale();
-  const displayNextLesson = tutor.nextLessonLabel
-    ? formatTutorNextLessonLabel(tutor.nextLessonLabel, locale)
-    : t("panels.tutors.unscheduled");
+  const userTimezone = useUserTimezone();
+  const displayNextLesson = tutor.nextLessonAt
+    ? formatTutorNextLessonLabel(
+        tutor.nextLessonLabel,
+        locale,
+        userTimezone,
+        tutor.nextLessonAt,
+      )
+    : tutor.nextLessonLabel
+      ? formatTutorNextLessonLabel(tutor.nextLessonLabel, locale, userTimezone)
+      : t("panels.tutors.unscheduled");
 
   return (
     <div className="group flex w-full flex-col gap-4 rounded-2xl border border-violet-100 bg-white p-4 transition-all hover:border-violet-200 hover:shadow-md hover:shadow-violet-100/40 sm:flex-row sm:items-center sm:gap-5">
@@ -181,7 +190,7 @@ export default function MyTutorsPanel({ tutors }: MyTutorsPanelProps) {
           </div>
           <div className="leading-tight">
             <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-violet-500">
-              {t("panels.tutors.eyebrow", { defaultValue: "My tutors" })}
+              {t("panels.tutors.eyebrow")}
             </p>
             <h2 className="text-xl font-extrabold text-slate-900 md:text-2xl">
               {t("panels.tutors.title")}

--- a/apps/web/src/views/main/my-lessons/index.tsx
+++ b/apps/web/src/views/main/my-lessons/index.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { useUserTimezone } from "@/hooks";
+import { getWeekStartMondayInTimezone } from "@/lib/timezone";
 import { useGetMyLessonsOverview } from "@/services/my-lessons/my-lessons.api";
 import MyLessonsCalendarSection from "./components/MyLessonsCalendarSection";
 import MyLessonsHeader from "./components/MyLessonsHeader";
@@ -26,9 +27,7 @@ export default function MyLessonsPage() {
   const [activeTab, setActiveTab] = useState<MyLessonsTab>("calendar");
   const [selectedDate, setSelectedDate] = useState(dayjs().tz(userTimezone));
 
-  const dayOfWeek = selectedDate.day();
-  const mondayOffset = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
-  const monday = selectedDate.subtract(mondayOffset, "day").startOf("day");
+  const monday = getWeekStartMondayInTimezone(userTimezone, selectedDate);
   const weekStartDate = monday.format("YYYY-MM-DD");
 
   const { data, isLoading } = useGetMyLessonsOverview(
@@ -40,13 +39,8 @@ export default function MyLessonsPage() {
     setSelectedDate((prev) => prev.subtract(7, "day"));
   const handleNextWeek = () => setSelectedDate((prev) => prev.add(7, "day"));
 
-  const isCurrentWeek = () => {
-    const today = dayjs().tz(userTimezone);
-    const todayDayOfWeek = today.day();
-    const todayMondayOffset = todayDayOfWeek === 0 ? 6 : todayDayOfWeek - 1;
-    const todayMonday = today.subtract(todayMondayOffset, "day").startOf("day");
-    return monday.isSame(todayMonday, "day");
-  };
+  const isCurrentWeek = () =>
+    monday.isSame(getWeekStartMondayInTimezone(userTimezone), "day");
 
   const handleGoToToday = () => {
     setSelectedDate(dayjs().tz(userTimezone));
@@ -89,6 +83,8 @@ export default function MyLessonsPage() {
                 <MyLessonsCalendarSection
                   calendar={data.calendar}
                   lessons={data.calendarLessons}
+                  weekStartYmd={weekStartDate}
+                  timezoneName={userTimezone}
                   onPrevWeek={handlePrevWeek}
                   onNextWeek={handleNextWeek}
                   onGoToToday={handleGoToToday}

--- a/apps/web/src/views/main/tutors/detail/components/TutorScheduleTab.tsx
+++ b/apps/web/src/views/main/tutors/detail/components/TutorScheduleTab.tsx
@@ -1,169 +1,82 @@
 'use client';
 
-
-
 import type { TutorAboutDto, TutorDetailAvailabilitySlotDto } from '@mezon-tutors/shared';
-
 import { utcWeeklySlotsToCalendarInstances } from '@mezon-tutors/shared';
-
 import { useTranslations } from 'next-intl';
-
 import { useMemo } from 'react';
-
 import { type ScheduleSlotInput, ScheduleViewer } from '@/components/common/ScheduleViewer';
-
-
+import { useUserTimezone } from '@/hooks';
 
 type TutorScheduleTabProps = {
-
   tutor: TutorAboutDto & {
-
     availability: TutorDetailAvailabilitySlotDto[];
-
   };
-
 };
 
+/** Weeks pre-expanded for ScheduleViewer modal navigation (viewer-local dates/times). */
+const WEEKS_AHEAD = 8;
 
-
-function buildScheduleSlotsFromUtcAvailability(
-
+function buildViewerScheduleSlots(
   availability: TutorDetailAvailabilitySlotDto[],
-
-  tutorTimezone: string,
-
-  weeksAhead = 4,
-
+  viewerTimezone: string,
 ): ScheduleSlotInput[] {
-
   const utcSlots = availability.map((slot) => ({
-
     dayOfWeek: slot.dayOfWeek,
-
     startTime: slot.startTime,
-
     endTime: slot.endTime,
-
     isActive: slot.isActive,
-
   }));
 
-
-
-  const slots: ScheduleSlotInput[] = [];
-
-  for (let weekOffset = 0; weekOffset < weeksAhead; weekOffset++) {
-
-    const weekInstances = utcWeeklySlotsToCalendarInstances(
-
+  const merged: ScheduleSlotInput[] = [];
+  for (let weekOffset = 0; weekOffset < WEEKS_AHEAD; weekOffset++) {
+    const instances = utcWeeklySlotsToCalendarInstances(
       utcSlots,
-
-      tutorTimezone,
-
+      viewerTimezone,
       weekOffset,
-
     );
-
-    for (const instance of weekInstances) {
-
-      slots.push({
-
-        date: instance.date,
-
-        startTime: instance.startTime,
-
-        endTime: instance.endTime,
-
-      });
-
-    }
-
+    merged.push(...instances);
   }
-
-  return slots;
-
+  return merged;
 }
-
-
 
 export function TutorScheduleTab({ tutor }: TutorScheduleTabProps) {
-
   const t = useTranslations('Tutors.Detail');
-
-  const scheduleTimezone = tutor.timezone || 'UTC';
-
-
+  const viewerTimezone = useUserTimezone();
 
   const availableSlots = useMemo(
-
-    () => buildScheduleSlotsFromUtcAvailability(tutor.availability, scheduleTimezone),
-
-    [tutor.availability, scheduleTimezone],
-
+    () => buildViewerScheduleSlots(tutor.availability, viewerTimezone),
+    [tutor.availability, viewerTimezone],
   );
 
-
-
-  const hasAvailability = tutor.availability?.length > 0;
-
-
+  const hasAvailability = tutor.availability?.some((slot) => slot.isActive) ?? false;
 
   if (!hasAvailability) {
-
     return (
-
       <div className="flex flex-col gap-4">
-
         <div>
-
           <h2 className="text-xl font-extrabold text-gray-900 mb-2">{t('scheduleTitle')}</h2>
-
-          <p className="text-sm text-gray-600">{t('scheduleHint', { timezone: tutor.timezone })}</p>
-
+          <p className="text-sm text-gray-600">
+            {t('scheduleHint', { timezone: viewerTimezone })}
+          </p>
         </div>
-
-
 
         <div className="bg-gray-50 border border-gray-200 rounded-xl p-6">
-
           <p className="text-center text-gray-600">{t('scheduleEmpty')}</p>
-
         </div>
-
       </div>
-
     );
-
   }
 
-
-
   return (
-
     <div className="flex flex-col gap-4">
-
       <div>
-
         <h2 className="text-xl font-extrabold text-gray-900 mb-2">{t('scheduleTitle')}</h2>
-
-        <p className="text-sm text-gray-600">{t('scheduleHint', { timezone: tutor.timezone })}</p>
-
+        <p className="text-sm text-gray-600">
+          {t('scheduleHint', { timezone: viewerTimezone })}
+        </p>
       </div>
 
-
-
-      <ScheduleViewer
-
-        availableSlots={availableSlots}
-
-        timezone={scheduleTimezone}
-
-      />
-
+      <ScheduleViewer availableSlots={availableSlots} timezone={viewerTimezone} />
     </div>
-
   );
-
 }
-
-

--- a/packages/shared/locales/en/my-lessons.json
+++ b/packages/shared/locales/en/my-lessons.json
@@ -63,6 +63,7 @@
       }
     },
     "tutors": {
+      "eyebrow": "My tutors",
       "title": "My tutors",
       "subtitle": "You have {count} active tutors this semester.",
       "findNewTutors": "+ Find New Tutors",

--- a/packages/shared/locales/vi/my-lessons.json
+++ b/packages/shared/locales/vi/my-lessons.json
@@ -63,6 +63,7 @@
       }
     },
     "tutors": {
+      "eyebrow": "Gia sư của tôi",
       "title": "Gia sư của tôi",
       "subtitle": "Bạn có {count} gia sư đang hoạt động trong học kỳ này.",
       "findNewTutors": "+ Tìm gia sư mới",

--- a/packages/shared/src/types/my-lessons-api.ts
+++ b/packages/shared/src/types/my-lessons-api.ts
@@ -37,6 +37,8 @@ export type MyLessonTutorApiItem = {
   availability: string
   completed_lessons: number
   next_lesson_label: string
+  /** ISO-8601 start of next lesson; format on client with viewer timezone when set. */
+  next_lesson_at?: string | null
   rating_average: number
   review_count: number
 }

--- a/packages/shared/src/types/my-lessons-api.ts
+++ b/packages/shared/src/types/my-lessons-api.ts
@@ -5,6 +5,8 @@ export type MyLessonApiStatus = 'upcoming' | 'completed'
 export type MyLessonWeekDayApiItem = {
   short_label: string
   date_label: string
+  /** YYYY-MM-DD in viewer timezone; used to align column headers with `day_index`. */
+  date_ymd: string
 }
 
 export type MyLessonApiItemSource = 'trial' | 'subscription'

--- a/packages/shared/src/utils/tutor-availability-utc.ts
+++ b/packages/shared/src/utils/tutor-availability-utc.ts
@@ -211,15 +211,21 @@ export function utcWeeklySlotsToTimezone(
 }
 
 /**
- * Expand UTC recurring slots into concrete calendar ranges for one week,
- * expressed in `targetTimezone` (for booking UIs).
+ * Expand UTC recurring slots into concrete calendar ranges for one viewer week
+ * (Mon–Sun in `targetTimezone`). Scans UTC calendar days overlapping that week so
+ * slots stored on UTC Sunday evening still appear on the viewer's Monday column.
  */
 export function utcWeeklySlotsToCalendarInstances(
   slots: WeeklyAvailabilitySlot[],
   targetTimezone: string,
   weekOffset = 0,
 ): CalendarAvailabilitySlot[] {
-  const utcMonday = getWeekMondayUtc().add(weekOffset * 7, 'day')
+  const viewerMonday = getWeekMondayInTimezone(targetTimezone).add(weekOffset * 7, 'day')
+  const weekStartLocal = viewerMonday.startOf('day')
+  const weekEndLocal = weekStartLocal.add(7, 'day')
+
+  const scanStartUtc = weekStartLocal.utc().subtract(1, 'day').startOf('day')
+  const scanEndUtc = weekEndLocal.utc().add(1, 'day').startOf('day')
   const all: CalendarAvailabilitySlot[] = []
 
   for (const slot of slots) {
@@ -227,12 +233,26 @@ export function utcWeeklySlotsToCalendarInstances(
       continue
     }
 
-    const utcDay = utcMonday.add(slot.dayOfWeek, 'day')
-    const startUtc = parseStartTimeOnDay(utcDay, slot.startTime, true)
-    const endUtc = parseEndTimeOnDay(utcDay, slot.endTime, true)
-    const startLocal = startUtc.tz(targetTimezone)
-    const endLocal = endUtc.tz(targetTimezone)
-    all.push(...splitInstantRangeToCalendar(startLocal, endLocal))
+    let cursor = scanStartUtc
+    while (cursor.isBefore(scanEndUtc)) {
+      if (dbDayOfWeekFromDayjs(cursor) !== slot.dayOfWeek) {
+        cursor = cursor.add(1, 'day')
+        continue
+      }
+
+      const startUtc = parseStartTimeOnDay(cursor, slot.startTime, true)
+      const endUtc = parseEndTimeOnDay(cursor, slot.endTime, true)
+      const startLocal = startUtc.tz(targetTimezone)
+      const endLocal = endUtc.tz(targetTimezone)
+
+      if (endLocal.isAfter(weekStartLocal) && startLocal.isBefore(weekEndLocal)) {
+        const clipStart = startLocal.isBefore(weekStartLocal) ? weekStartLocal : startLocal
+        const clipEnd = endLocal.isAfter(weekEndLocal) ? weekEndLocal : endLocal
+        all.push(...splitInstantRangeToCalendar(clipStart, clipEnd))
+      }
+
+      cursor = cursor.add(1, 'day')
+    }
   }
 
   return all


### PR DESCRIPTION
Show timezone base on each viewers for both of trial and plan 
<img width="1636" height="817" alt="image" src="https://github.com/user-attachments/assets/019684f9-ac1c-460b-98a8-5976a0361305" />
<img width="1393" height="761" alt="image" src="https://github.com/user-attachments/assets/4e050996-ca7f-493c-aa98-63e7dbe5aa4e" />

Fix error show 25h
<img width="396" height="295" alt="image" src="https://github.com/user-attachments/assets/5eccba16-3c15-4b72-ad16-307cb09b54d1" />

Fix Sunday-evening UTC slot missing on viewer’s Monday column
<img width="1851" height="712" alt="image" src="https://github.com/user-attachments/assets/4d395096-a7be-4d5b-a008-3015d3e99518" />





