### PR TITLE
fix(db): order cancel_reschedule_reason index rename after table crea…

### DIFF
--- a/packages/db/prisma/migrations/20260601120001_rename_cancel_reschedule_reason_index/migration.sql
+++ b/packages/db/prisma/migrations/20260601120001_rename_cancel_reschedule_reason_index/migration.sql
@@ -1,0 +1,5 @@
+-- RenameIndex
+-- Must run AFTER 20260601120000 creates the index. Guarded with IF EXISTS so it is
+-- a no-op on databases where the index was already renamed or does not yet exist.
+ALTER INDEX IF EXISTS "cancel_reschedule_reason_subscription_enrollment_id_su_idx"
+  RENAME TO "cancel_reschedule_reason_subscription_enrollment_id_subscri_idx";


### PR DESCRIPTION
…tion

The rename migration was generated with timestamp 20260527020656, which sorts before 20260601120000 that creates the table and index. On a fresh deploy the rename ran before the index existed, failing with P3009.

Move the rename to 20260601120001 (after creation) and guard it with IF EXISTS so it is idempotent.