### PR TITLE
Cloudinary security view upload

### DIFF
--- a/apps/api/scripts/migrate-assets-to-private.ts
+++ b/apps/api/scripts/migrate-assets-to-private.ts
@@ -1,0 +1,131 @@
+import { PrismaClient } from '@mezon-tutors/db';
+import { v2 as cloudinary } from 'cloudinary';
+
+const prisma = new PrismaClient();
+
+function configureCloudinary() {
+  const cloudName = process.env.CLOUDINARY_CLOUD_NAME?.trim();
+  const apiKey = process.env.CLOUDINARY_API_KEY?.trim();
+  const apiSecret = process.env.CLOUDINARY_API_SECRET?.trim();
+  if (!cloudName || !apiKey || !apiSecret) {
+    throw new Error('Missing CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, or CLOUDINARY_API_SECRET');
+  }
+  cloudinary.config({ cloud_name: cloudName, api_key: apiKey, api_secret: apiSecret, secure: true });
+}
+
+function guessResourceType(publicId: string): 'image' | 'raw' {
+  const lower = publicId.toLowerCase();
+  if (lower.endsWith('.pdf') || lower.includes('/raw/')) return 'raw';
+  return 'image';
+}
+
+function guessFormat(publicId: string): string {
+  const ext = publicId.split('.').pop()?.toLowerCase();
+  if (ext === 'jpeg') return 'jpg';
+  if (ext && ['jpg', 'png', 'gif', 'webp', 'pdf'].includes(ext)) return ext;
+  return 'jpg';
+}
+
+async function fetchPublicAsset(publicId: string, resourceType: 'image' | 'raw'): Promise<Buffer> {
+  const format = guessFormat(publicId);
+  const url = cloudinary.url(publicId, {
+    resource_type: resourceType,
+    type: 'upload',
+    secure: true,
+    format,
+  });
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Fetch failed (${res.status}) for ${publicId}`);
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+async function reuploadAsPrivate(
+  publicId: string,
+  resourceType: 'image' | 'raw'
+): Promise<string> {
+  const buffer = await fetchPublicAsset(publicId, resourceType);
+  const result = await new Promise<{ public_id: string }>((resolve, reject) => {
+    const stream = cloudinary.uploader.upload_stream(
+      {
+        resource_type: resourceType,
+        type: 'private',
+        folder: publicId.includes('/') ? publicId.split('/').slice(0, -1).join('/') : undefined,
+        public_id: publicId.includes('/') ? publicId.split('/').pop() : publicId,
+        overwrite: true,
+      },
+      (err, uploadResult) => {
+        if (err) reject(err);
+        else if (!uploadResult) reject(new Error('No upload result'));
+        else resolve(uploadResult);
+      }
+    );
+    stream.end(buffer);
+  });
+
+  try {
+    await cloudinary.uploader.destroy(publicId, { resource_type: resourceType, type: 'upload' });
+  } catch {
+    // Public asset may already be gone if overwrite migrated in-place
+  }
+
+  return result.public_id;
+}
+
+async function migrateRecord(label: string, id: string, fileKey: string) {
+  if (!fileKey?.trim() || /^https?:\/\//i.test(fileKey)) {
+    console.log(`  skip ${label} ${id}: invalid or URL file_key (run Phase 1 first)`);
+    return 'skipped';
+  }
+  const resourceType = guessResourceType(fileKey);
+  try {
+    const newPublicId = await reuploadAsPrivate(fileKey, resourceType);
+    if (newPublicId !== fileKey) {
+      if (label.startsWith('identity')) {
+        await prisma.identityVerification.update({ where: { id }, data: { fileKey: newPublicId } });
+      } else {
+        await prisma.professionalDocument.update({ where: { id }, data: { fileKey: newPublicId } });
+      }
+    }
+    console.log(`  ok ${label} ${id} → private (${newPublicId})`);
+    return 'ok';
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`  fail ${label} ${id}: ${msg}`);
+    return 'fail';
+  }
+}
+
+async function main() {
+  configureCloudinary();
+  let ok = 0;
+  let fail = 0;
+  let skipped = 0;
+
+  console.log('Migrating identity_verification...');
+  for (const row of await prisma.identityVerification.findMany({ select: { id: true, fileKey: true } })) {
+    const r = await migrateRecord('identity', row.id, row.fileKey);
+    if (r === 'ok') ok++;
+    else if (r === 'fail') fail++;
+    else skipped++;
+  }
+
+  console.log('Migrating professional_document...');
+  for (const row of await prisma.professionalDocument.findMany({ select: { id: true, fileKey: true } })) {
+    const r = await migrateRecord('document', row.id, row.fileKey);
+    if (r === 'ok') ok++;
+    else if (r === 'fail') fail++;
+    else skipped++;
+  }
+
+  console.log(`\nDone. ok=${ok} fail=${fail} skipped=${skipped}`);
+  if (fail > 0) process.exitCode = 1;
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/apps/api/src/modules/cloudinary/cloudinary.controller.ts
+++ b/apps/api/src/modules/cloudinary/cloudinary.controller.ts
@@ -70,6 +70,40 @@ export class CloudinaryController {
     });
   }
 
+  @Post('upload-private')
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary' },
+        folder: { type: 'string' },
+        resourceType: { type: 'string', enum: ['image', 'video', 'raw', 'auto'] },
+      },
+      required: ['file'],
+    },
+  })
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: memoryStorage(),
+      limits: { fileSize: 20 * 1024 * 1024 },
+    })
+  )
+  async uploadPrivateFile(
+    @UploadedFile() file: Express.Multer.File,
+    @Body('folder') folder?: string,
+    @Body('resourceType') resourceType?: 'image' | 'video' | 'raw' | 'auto'
+  ) {
+    if (!file?.buffer) {
+      throw new BadRequestException('File is required');
+    }
+
+    return this.cloudinaryService.uploadPrivateFile(file.buffer, {
+      folder,
+      resourceType,
+    });
+  }
+
   @Delete('asset')
   async deleteFile(
     @Query('publicId') publicId: string,

--- a/apps/api/src/modules/cloudinary/cloudinary.service.ts
+++ b/apps/api/src/modules/cloudinary/cloudinary.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Injectable,
   InternalServerErrorException,
+  NotFoundException,
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { v2 as cloudinary } from 'cloudinary';
@@ -11,6 +12,13 @@ type UploadOptions = {
   folder?: string;
   publicId?: string;
   resourceType?: 'image' | 'video' | 'raw' | 'auto';
+  isPrivate?: boolean;
+};
+
+type ResolvedCloudinaryAsset = {
+  publicId: string;
+  format: string;
+  resourceType: 'image' | 'video' | 'raw';
 };
 
 @Injectable()
@@ -55,6 +63,7 @@ export class CloudinaryService {
           folder: options?.folder,
           public_id: options?.publicId,
           resource_type: options?.resourceType || 'auto',
+          type: options?.isPrivate ? 'private' : 'upload',
         },
         (error, result) => {
           if (error) {
@@ -84,6 +93,18 @@ export class CloudinaryService {
     });
   }
 
+  async uploadPrivateFile(
+    buffer: Buffer,
+    options?: Omit<UploadOptions, 'isPrivate'>
+  ): Promise<{ publicId: string; resourceType: string; format?: string }> {
+    const result = await this.uploadFile(buffer, { ...options, isPrivate: true });
+    return {
+      publicId: result.publicId,
+      resourceType: result.resourceType,
+      format: result.format,
+    };
+  }
+
   async deleteFile(publicId: string, resourceType: 'image' | 'video' | 'raw' = 'image') {
     this.ensureConfigured();
     if (!publicId?.trim()) {
@@ -98,6 +119,137 @@ export class CloudinaryService {
       publicId,
       result: result.result,
     };
+  }
+
+  /**
+   * Accepts either a Cloudinary public_id or a full secure_url stored in fileKey.
+   * Legacy records store secure_url; newer records may store public_id directly.
+   */
+  resolveAssetReference(fileKey: string): ResolvedCloudinaryAsset {
+    const trimmed = fileKey.trim();
+    if (!trimmed) {
+      throw new BadRequestException('fileKey is required');
+    }
+
+    if (!/^https?:\/\//i.test(trimmed)) {
+      const lastSegment = trimmed.split('/').pop() ?? trimmed;
+      const dotIdx = lastSegment.lastIndexOf('.');
+      if (dotIdx > 0) {
+        return {
+          publicId: trimmed.slice(0, trimmed.length - (lastSegment.length - dotIdx)),
+          format: lastSegment.slice(dotIdx + 1),
+          resourceType: 'image',
+        };
+      }
+      return { publicId: trimmed, format: 'jpg', resourceType: 'image' };
+    }
+
+    const url = new URL(trimmed);
+    const pathParts = url.pathname.split('/').filter(Boolean);
+    const uploadIdx = pathParts.indexOf('upload');
+    if (uploadIdx < 1) {
+      throw new BadRequestException('Invalid Cloudinary URL');
+    }
+
+    const resourceType = pathParts[uploadIdx - 1] as ResolvedCloudinaryAsset['resourceType'];
+    let segments = pathParts.slice(uploadIdx + 1);
+
+    if (segments[0]?.match(/^v\d+$/)) {
+      segments = segments.slice(1);
+    }
+
+    while (
+      segments.length > 1 &&
+      /^[a-z0-9_,.-]+$/i.test(segments[0]) &&
+      (segments[0].includes('_') || segments[0].includes(','))
+    ) {
+      segments = segments.slice(1);
+    }
+
+    const filename = segments.pop() ?? '';
+    const dotIdx = filename.lastIndexOf('.');
+    const format = dotIdx >= 0 ? filename.slice(dotIdx + 1) : 'jpg';
+    const publicId = [...segments, dotIdx >= 0 ? filename.slice(0, dotIdx) : filename].join('/');
+
+    if (!publicId) {
+      throw new BadRequestException('Could not extract public_id from Cloudinary URL');
+    }
+
+    return {
+      publicId,
+      format,
+      resourceType: resourceType === 'video' || resourceType === 'raw' ? resourceType : 'image',
+    };
+  }
+
+  private async fetchFromUrl(
+    url: string,
+    notFoundLabel: string
+  ): Promise<{ buffer: Buffer; contentType: string }> {
+    const response = await fetch(url);
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new NotFoundException(`Asset not found: ${notFoundLabel}`);
+      }
+      throw new InternalServerErrorException(
+        `Failed to fetch asset from Cloudinary: ${response.status}`
+      );
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return {
+      buffer: Buffer.from(arrayBuffer),
+      contentType: response.headers.get('content-type') ?? 'application/octet-stream',
+    };
+  }
+
+  /**
+   * Fetches a Cloudinary asset server-to-server and returns it as a Buffer.
+   * fileKey may be a public_id or a legacy secure_url (public upload).
+   */
+  async fetchPrivateAsset(
+    fileKey: string,
+    resourceType?: 'image' | 'raw'
+  ): Promise<{ buffer: Buffer; contentType: string }> {
+    this.ensureConfigured();
+    if (!fileKey?.trim()) {
+      throw new BadRequestException('fileKey is required');
+    }
+
+    const trimmed = fileKey.trim();
+    const resolved = this.resolveAssetReference(trimmed);
+    const effectiveResourceType = resourceType ?? resolved.resourceType;
+    const format = resolved.format.toLowerCase() === 'jpeg' ? 'jpg' : resolved.format;
+    const isLegacyPublicUrl = /^https?:\/\//i.test(trimmed);
+
+    // Legacy uploads are public (type: upload) — private_download_url only works for private/authenticated assets.
+    if (isLegacyPublicUrl) {
+      return this.fetchFromUrl(trimmed, resolved.publicId);
+    }
+
+    const expiresAt = Math.floor(Date.now() / 1000) + 60;
+    const privateUrl = cloudinary.utils.private_download_url(resolved.publicId, format, {
+      resource_type: effectiveResourceType === 'raw' ? 'raw' : 'image',
+      type: 'private',
+      expires_at: expiresAt,
+    });
+
+    try {
+      return await this.fetchFromUrl(privateUrl, resolved.publicId);
+    } catch (error) {
+      if (!(error instanceof NotFoundException)) {
+        throw error;
+      }
+    }
+
+    const legacyPublicUrl = cloudinary.url(resolved.publicId, {
+      resource_type: effectiveResourceType,
+      type: 'upload',
+      secure: true,
+      format,
+    });
+
+    return this.fetchFromUrl(legacyPublicUrl, resolved.publicId);
   }
 
   createUploadSignature(params: { folder?: string; publicId?: string; timestamp?: number }) {

--- a/apps/api/src/modules/tutor-application/tutor-application.controller.ts
+++ b/apps/api/src/modules/tutor-application/tutor-application.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Param, Body, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Param, Body, UseGuards, Res, NotFoundException } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AdminGuard } from '../../common/guards/admin.guard';
@@ -12,13 +12,20 @@ import type {
   TutorApplicationMetrics,
 } from '@mezon-tutors/shared';
 import { TutorProfile } from '@mezon-tutors/db';
+import type { Response } from 'express';
+import { CloudinaryService } from '../cloudinary/cloudinary.service';
+import { PrismaService } from '../../prisma/prisma.service';
 
 @Controller('admin')
 @ApiTags('Admin - Tutor applications')
 @UseGuards(JwtAuthGuard, AdminGuard)
 @ApiBearerAuth()
 export class TutorApplicationController {
-  constructor(private readonly tutorApplicationService: TutorApplicationService) {}
+  constructor(
+    private readonly tutorApplicationService: TutorApplicationService,
+    private readonly cloudinaryService: CloudinaryService,
+    private readonly prisma: PrismaService
+  ) {}
 
   @Get('tutor-applications')
   async getList(): Promise<TutorProfile[]> {
@@ -55,5 +62,42 @@ export class TutorApplicationController {
   @Post('tutor-admin-notes')
   async createAdminNote(@Body() dto: CreateAdminNoteDto): Promise<TutorAdminNote> {
     return this.tutorApplicationService.createAdminNote(dto);
+  }
+
+  @Get('tutor-profiles/:tutorId/identity-verification/image')
+  async proxyIdentityVerificationImage(
+    @Param('tutorId') tutorId: string,
+    @Res() res: Response
+  ): Promise<void> {
+    const verification = await this.prisma.identityVerification.findUnique({
+      where: { tutorId },
+      select: { fileKey: true },
+    });
+    if (!verification?.fileKey) {
+      throw new NotFoundException('Identity verification document not found');
+    }
+    const { buffer, contentType } = await this.cloudinaryService.fetchPrivateAsset(verification.fileKey);
+    res.set('Content-Type', contentType);
+    res.set('Cache-Control', 'private, no-store');
+    res.send(buffer);
+  }
+
+  @Get('tutor-profiles/:tutorId/documents/:documentId/image')
+  async proxyProfessionalDocumentImage(
+    @Param('tutorId') tutorId: string,
+    @Param('documentId') documentId: string,
+    @Res() res: Response
+  ): Promise<void> {
+    const doc = await this.prisma.professionalDocument.findFirst({
+      where: { id: documentId, tutorId },
+      select: { fileKey: true },
+    });
+    if (!doc?.fileKey) {
+      throw new NotFoundException('Professional document not found');
+    }
+    const { buffer, contentType } = await this.cloudinaryService.fetchPrivateAsset(doc.fileKey);
+    res.set('Content-Type', contentType);
+    res.set('Cache-Control', 'private, no-store');
+    res.send(buffer);
   }
 }

--- a/apps/api/src/modules/tutor-application/tutor-application.mapper.ts
+++ b/apps/api/src/modules/tutor-application/tutor-application.mapper.ts
@@ -76,7 +76,7 @@ export class TutorApplicationMapper {
       uploadedAt: doc.uploadedAt,
       specialization: doc.specialization,
       yearOfComplete: doc.yearOfComplete,
-      fileKey: doc.fileKey,
+      hasFile: Boolean(doc.fileKey?.trim()),
       institution: doc.institution,
       reviewedAt: doc.reviewedAt,
     };
@@ -97,7 +97,7 @@ export class TutorApplicationMapper {
       notExpired: verification.notExpired,
       photoClarity: verification.photoClarity,
       uploadedAt: verification.uploadedAt,
-      fileKey: verification.fileKey,
+      hasFile: Boolean(verification.fileKey?.trim()),
       reviewedAt: verification.reviewedAt,
     };
   }

--- a/apps/api/src/modules/tutor-application/tutor-application.module.ts
+++ b/apps/api/src/modules/tutor-application/tutor-application.module.ts
@@ -3,12 +3,13 @@ import { PrismaModule } from '../../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
 import { MezonBotModule } from '../mezon-bot/mezon-bot.module';
 import { NotificationModule } from '../notification/notification.module';
+import { CloudinaryModule } from '../cloudinary/cloudinary.module';
 import { TutorApplicationController } from './tutor-application.controller';
 import { TutorApplicationService } from './tutor-application.service';
 import { TutorApplicationMapper } from './tutor-application.mapper';
 
 @Module({
-  imports: [PrismaModule, AuthModule, NotificationModule, MezonBotModule],
+  imports: [PrismaModule, AuthModule, NotificationModule, MezonBotModule, CloudinaryModule],
   controllers: [TutorApplicationController],
   providers: [TutorApplicationService, TutorApplicationMapper],
   exports: [TutorApplicationService, TutorApplicationMapper],

--- a/apps/api/src/modules/tutor-profile/tutor-profile.service.ts
+++ b/apps/api/src/modules/tutor-profile/tutor-profile.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import {
   CountryLabel,
@@ -268,6 +268,69 @@ export class TutorProfileService {
     }
   }
 
+  private normalizeCloudinaryPublicId(value: string | undefined): string | null {
+    const trimmed = value?.trim();
+    if (!trimmed) return null;
+    if (/^https?:\/\//i.test(trimmed)) {
+      throw new BadRequestException('Secure document reference must be a Cloudinary public_id, not a URL');
+    }
+    return trimmed;
+  }
+
+  private sanitizeMyProfileForClient(
+    profile: Prisma.TutorProfileGetPayload<{
+      include: {
+        languages: true;
+        availability: true;
+        identityVerification: true;
+        professionalDocuments: true;
+        trialLessonPrice: true;
+      };
+    }>
+  ) {
+    const { identityVerification, professionalDocuments, trialLessonPrice, ...rest } = profile;
+
+    const profileData = trialLessonPrice
+      ? {
+          ...rest,
+          trialLessonPrice: {
+            ...trialLessonPrice,
+            vnd: trialLessonPrice.vnd.toString(),
+          },
+        }
+      : rest;
+
+    return {
+      ...profileData,
+      identityVerification: identityVerification
+        ? {
+            id: identityVerification.id,
+            tutorId: identityVerification.tutorId,
+            status: identityVerification.status,
+            nameMatch: identityVerification.nameMatch,
+            notExpired: identityVerification.notExpired,
+            photoClarity: identityVerification.photoClarity,
+            uploadedAt: identityVerification.uploadedAt,
+            reviewedAt: identityVerification.reviewedAt,
+            hasFile: Boolean(identityVerification.fileKey?.trim()),
+          }
+        : null,
+      professionalDocuments: professionalDocuments.map((doc) => ({
+        id: doc.id,
+        tutorId: doc.tutorId,
+        name: doc.name,
+        type: doc.type,
+        status: doc.status,
+        uploadedAt: doc.uploadedAt,
+        specialization: doc.specialization,
+        yearOfComplete: doc.yearOfComplete,
+        institution: doc.institution,
+        reviewedAt: doc.reviewedAt,
+        hasFile: Boolean(doc.fileKey?.trim()),
+      })),
+    };
+  }
+
   async getMyProfile(userId: string) {
     const profile = await this.prisma.tutorProfile.findUnique({
       where: { userId },
@@ -288,13 +351,7 @@ export class TutorProfileService {
       };
     }
 
-    const profileData = profile.trialLessonPrice ? {
-      ...profile,
-      trialLessonPrice: {
-        ...profile.trialLessonPrice,
-        vnd: profile.trialLessonPrice.vnd.toString(),
-      },
-    } : profile;
+    const profileData = this.sanitizeMyProfileForClient(profile);
 
     return {
       hasProfile: true,
@@ -416,23 +473,26 @@ export class TutorProfileService {
       await this.upsertTutorAvailabilitySlotByUserId(profile.id, dto.availability);
     }
 
-    if (dto.identityPhotoUrl && profile) {
-      await this.createTutorIdentityVerificationByUserId(profile.id, dto.identityPhotoUrl);
+    const identityPublicId = this.normalizeCloudinaryPublicId(dto.identityPhotoPublicId);
+    if (identityPublicId && profile) {
+      await this.createTutorIdentityVerificationByUserId(profile.id, identityPublicId);
     }
 
-    if (dto.teachingCertificateFileUrl && profile) {
+    const teachingCertPublicId = this.normalizeCloudinaryPublicId(dto.teachingCertificatePublicId);
+    if (teachingCertPublicId && profile) {
       await this.createTutorCertificateByUserId(profile.id, {
         name: dto.teachingCertificateName,
-        fileUrl: dto.teachingCertificateFileUrl,
+        fileUrl: teachingCertPublicId,
         type: ProfessionalDocumentType.CERTIFICATE,
         yearOfComplete: dto.teachingYear ? parseInt(dto.teachingYear, 10) : undefined,
       });
     }
 
-    if (dto.educationFileUrl && profile) {
+    const educationPublicId = this.normalizeCloudinaryPublicId(dto.educationPublicId);
+    if (educationPublicId && profile) {
       await this.createTutorCertificateByUserId(profile.id, {
         name: dto.degree,
-        fileUrl: dto.educationFileUrl,
+        fileUrl: educationPublicId,
         type: ProfessionalDocumentType.DEGREE,
         institution: dto.university,
         specialization: dto.specialization,
@@ -510,23 +570,26 @@ export class TutorProfileService {
       await this.upsertTutorAvailabilitySlotByUserId(profile.id, dto.availability);
     }
 
-    if (dto.identityPhotoUrl && profile) {
-      await this.upsertTutorIdentityVerificationByUserId(profile.id, dto.identityPhotoUrl);
+    const identityPublicId = this.normalizeCloudinaryPublicId(dto.identityPhotoPublicId);
+    if (identityPublicId && profile) {
+      await this.upsertTutorIdentityVerificationByUserId(profile.id, identityPublicId);
     }
 
-    if (dto.teachingCertificateFileUrl && profile) {
+    const teachingCertPublicId = this.normalizeCloudinaryPublicId(dto.teachingCertificatePublicId);
+    if (teachingCertPublicId && profile) {
       await this.upsertTutorCertificateByUserId(profile.id, {
         name: dto.teachingCertificateName,
-        fileUrl: dto.teachingCertificateFileUrl,
+        fileUrl: teachingCertPublicId,
         type: ProfessionalDocumentType.CERTIFICATE,
         yearOfComplete: dto.teachingYear ? parseInt(dto.teachingYear, 10) : undefined,
       });
     }
 
-    if (dto.educationFileUrl && profile) {
+    const educationPublicId = this.normalizeCloudinaryPublicId(dto.educationPublicId);
+    if (educationPublicId && profile) {
       await this.upsertTutorCertificateByUserId(profile.id, {
         name: dto.degree,
-        fileUrl: dto.educationFileUrl,
+        fileUrl: educationPublicId,
         type: ProfessionalDocumentType.DEGREE,
         institution: dto.university,
         specialization: dto.specialization,
@@ -640,12 +703,12 @@ export class TutorProfileService {
 
   async createTutorIdentityVerificationByUserId(
     userId: string,
-    identityPhotoUrl: string
+    cloudinaryPublicId: string
   ): Promise<void> {
     await this.prisma.identityVerification.create({
       data: {
         tutorId: userId,
-        fileKey: identityPhotoUrl,
+        fileKey: cloudinaryPublicId,
         status: IdentityVerificationStatus.PENDING,
       },
     });
@@ -653,18 +716,18 @@ export class TutorProfileService {
 
   async upsertTutorIdentityVerificationByUserId(
     userId: string,
-    identityPhotoUrl: string
+    cloudinaryPublicId: string
   ): Promise<void> {
     await this.prisma.identityVerification.upsert({
       where: { tutorId: userId },
       update: {
-        fileKey: identityPhotoUrl,
+        fileKey: cloudinaryPublicId,
         status: IdentityVerificationStatus.PENDING,
         uploadedAt: new Date(),
       },
       create: {
         tutorId: userId,
-        fileKey: identityPhotoUrl,
+        fileKey: cloudinaryPublicId,
         status: IdentityVerificationStatus.PENDING,
       },
     });

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -50,5 +50,7 @@
       "node",
       "multer"
     ]
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "scripts"]
 }

--- a/apps/web/src/components/ui/SecureImage.tsx
+++ b/apps/web/src/components/ui/SecureImage.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useAtomValue } from "jotai";
+import { useEffect, useRef, useState } from "react";
+import { accessTokenAtom } from "@/store/token.atom";
+import { BASE_URL } from "@/services/api-client";
+
+type SecureImageProps = {
+  /** Backend proxy path, e.g. /admin/tutor-profiles/:id/identity-verification/image */
+  proxyPath: string;
+  alt: string;
+  className?: string;
+};
+
+/**
+ * Fetches a backend-proxied image using the current JWT access token
+ * and renders it as a blob URL so the real Cloudinary URL is never exposed.
+ */
+export default function SecureImage({ proxyPath, alt, className }: SecureImageProps) {
+  const token = useAtomValue(accessTokenAtom);
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+  const prevBlobUrl = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!proxyPath || !token) return;
+
+    let cancelled = false;
+    setError(false);
+
+    const url = `${BASE_URL}${proxyPath}`;
+    fetch(url, { headers: { Authorization: `Bearer ${token}` } })
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status}`);
+        return res.blob();
+      })
+      .then((blob) => {
+        if (cancelled) return;
+        const objectUrl = URL.createObjectURL(blob);
+        if (prevBlobUrl.current) URL.revokeObjectURL(prevBlobUrl.current);
+        prevBlobUrl.current = objectUrl;
+        setBlobUrl(objectUrl);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [proxyPath, token]);
+
+  useEffect(() => {
+    return () => {
+      if (prevBlobUrl.current) URL.revokeObjectURL(prevBlobUrl.current);
+    };
+  }, []);
+
+  if (error) return <span className="text-xs text-red-500">Failed to load image</span>;
+  if (!blobUrl) return <span className="text-xs text-slate-400">Loading…</span>;
+  return <img src={blobUrl} alt={alt} className={className} />;
+}

--- a/apps/web/src/lib/open-secure-proxy-in-new-tab.ts
+++ b/apps/web/src/lib/open-secure-proxy-in-new-tab.ts
@@ -1,0 +1,29 @@
+import { BASE_URL } from "@/services/api-client";
+
+/**
+ * Fetches a backend-proxied file with JWT and opens it in a new browser tab.
+ * Uses a blob URL so the Cloudinary URL is never exposed.
+ */
+export async function openSecureProxyInNewTab(
+  proxyPath: string,
+  token: string | null,
+): Promise<boolean> {
+  if (!token?.trim()) return false;
+
+  const res = await fetch(`${BASE_URL}${proxyPath}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) return false;
+
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const opened = window.open(objectUrl, "_blank", "noopener,noreferrer");
+  if (!opened) {
+    URL.revokeObjectURL(objectUrl);
+    return false;
+  }
+
+  // Keep blob alive while the new tab loads; revoke after a delay.
+  setTimeout(() => URL.revokeObjectURL(objectUrl), 60_000);
+  return true;
+}

--- a/apps/web/src/services/cloudinary/cloudinary.service.ts
+++ b/apps/web/src/services/cloudinary/cloudinary.service.ts
@@ -14,7 +14,31 @@ type CloudinarySignatureResponse = {
   publicId: string | null;
 };
 
+type CloudinaryPrivateUploadResponse = {
+  publicId: string;
+  resourceType: string;
+  format?: string;
+};
+
 class CloudinaryService {
+  async uploadPrivateFile(
+    file: File,
+    folder: string,
+    resourceType: 'auto' | 'image' | 'video' | 'raw' = 'auto'
+  ): Promise<{ publicId: string }> {
+    const formData = new FormData();
+    formData.append('file', file);
+    if (folder) formData.append('folder', folder);
+    if (resourceType) formData.append('resourceType', resourceType);
+
+    const result = await apiClient.post<CloudinaryPrivateUploadResponse>(
+      '/cloudinary/upload-private',
+      formData
+    );
+
+    return { publicId: result.publicId };
+  }
+
   async uploadFileWithSignature(
     file: File,
     folder: string,

--- a/apps/web/src/views/admin/tutor-applications/detail/components/IdentityVerificationCard.tsx
+++ b/apps/web/src/views/admin/tutor-applications/detail/components/IdentityVerificationCard.tsx
@@ -2,15 +2,20 @@
 
 import type { IdentityVerification } from "@mezon-tutors/shared";
 import dayjs from "dayjs";
-import { ExternalLink } from "lucide-react";
+import { Download } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useAtomValue } from "jotai";
 import { Card, CardContent } from "@/components/ui";
 import { buttonVariants } from "@/components/ui/button";
+import SecureImage from "@/components/ui/SecureImage";
 import { cn } from "@/lib/utils";
+import { accessTokenAtom } from "@/store/token.atom";
+import { BASE_URL } from "@/services/api-client";
 import StatusBadge from "../../components/StatusBadge";
 
 type IdentityVerificationCardProps = {
   verification: IdentityVerification | null;
+  tutorId: string;
 };
 
 const formatDate = (date: Date | string | null | undefined) => {
@@ -19,20 +24,32 @@ const formatDate = (date: Date | string | null | undefined) => {
   return d.isValid() ? d.format("MMM DD, YYYY") : "—";
 };
 
-const isLikelyHttp = (s: string) => /^https?:\/\//i.test(s.trim());
-
-const isLikelyRasterImage = (s: string) => {
-  const base = s.split("?")[0] ?? s;
-  return /\.(jpe?g|png|gif|webp|bmp)$/i.test(base);
-};
-
 export default function IdentityVerificationCard({
   verification,
+  tutorId,
 }: IdentityVerificationCardProps) {
   const t = useTranslations(
     "AdminTutorApplicationDetail.sections.documents.identityVerification",
   );
-  const fileKey = verification?.fileKey?.trim() ?? "";
+  const token = useAtomValue(accessTokenAtom);
+  const hasDocument = verification?.hasFile ?? false;
+  const proxyPath = `/admin/tutor-profiles/${tutorId}/identity-verification/image`;
+
+  const handleDownload = async () => {
+    if (!token) return;
+    const res = await fetch(`${BASE_URL}${proxyPath}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const ext = blob.type.split("/")[1] ?? "jpg";
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `identity-verification.${ext}`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
 
   return (
     <Card className="border-slate-200">
@@ -40,7 +57,7 @@ export default function IdentityVerificationCard({
         <h3 className="text-base font-semibold text-slate-900">{t("title")}</h3>
         <p className="mt-1 text-xs text-slate-500">{t("subtitle")}</p>
 
-        {!fileKey ? (
+        {!hasDocument ? (
           <p className="mt-4 text-sm text-slate-600">{t("noDocument")}</p>
         ) : (
           <div className="mt-4 space-y-4">
@@ -55,32 +72,24 @@ export default function IdentityVerificationCard({
             <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
               {t("idTypeLabel")}
             </p>
-            {isLikelyHttp(fileKey) && isLikelyRasterImage(fileKey) ? (
-              <a
-                href={fileKey}
-                target="_blank"
-                rel="noreferrer"
-                className="block overflow-hidden rounded-lg border border-slate-200 bg-slate-50"
-              >
-                <img
-                  src={fileKey}
-                  alt={t("idTypeLabel")}
-                  className="max-h-[320px] w-full object-contain"
-                />
-              </a>
-            ) : null}
-            <a
-              href={fileKey}
-              target="_blank"
-              rel="noreferrer"
+            <div className="overflow-hidden rounded-lg border border-slate-200 bg-slate-50">
+              <SecureImage
+                proxyPath={proxyPath}
+                alt={t("idTypeLabel")}
+                className="max-h-[320px] w-full object-contain"
+              />
+            </div>
+            <button
+              type="button"
+              onClick={handleDownload}
               className={cn(
                 buttonVariants({ variant: "outline", size: "sm" }),
-                "inline-flex w-fit no-underline",
+                "inline-flex w-fit",
               )}
             >
-              <ExternalLink className="mr-2 h-4 w-4" />
+              <Download className="mr-2 h-4 w-4" />
               {t("download")}
-            </a>
+            </button>
           </div>
         )}
       </CardContent>

--- a/apps/web/src/views/admin/tutor-applications/detail/components/IdentityVerificationCard.tsx
+++ b/apps/web/src/views/admin/tutor-applications/detail/components/IdentityVerificationCard.tsx
@@ -2,15 +2,15 @@
 
 import type { IdentityVerification } from "@mezon-tutors/shared";
 import dayjs from "dayjs";
-import { Download } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useAtomValue } from "jotai";
 import { Card, CardContent } from "@/components/ui";
 import { buttonVariants } from "@/components/ui/button";
 import SecureImage from "@/components/ui/SecureImage";
 import { cn } from "@/lib/utils";
+import { openSecureProxyInNewTab } from "@/lib/open-secure-proxy-in-new-tab";
 import { accessTokenAtom } from "@/store/token.atom";
-import { BASE_URL } from "@/services/api-client";
 import StatusBadge from "../../components/StatusBadge";
 
 type IdentityVerificationCardProps = {
@@ -35,20 +35,8 @@ export default function IdentityVerificationCard({
   const hasDocument = verification?.hasFile ?? false;
   const proxyPath = `/admin/tutor-profiles/${tutorId}/identity-verification/image`;
 
-  const handleDownload = async () => {
-    if (!token) return;
-    const res = await fetch(`${BASE_URL}${proxyPath}`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    if (!res.ok) return;
-    const blob = await res.blob();
-    const ext = blob.type.split("/")[1] ?? "jpg";
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `identity-verification.${ext}`;
-    a.click();
-    URL.revokeObjectURL(url);
+  const handleOpenInNewTab = () => {
+    void openSecureProxyInNewTab(proxyPath, token);
   };
 
   return (
@@ -81,13 +69,13 @@ export default function IdentityVerificationCard({
             </div>
             <button
               type="button"
-              onClick={handleDownload}
+              onClick={handleOpenInNewTab}
               className={cn(
                 buttonVariants({ variant: "outline", size: "sm" }),
                 "inline-flex w-fit",
               )}
             >
-              <Download className="mr-2 h-4 w-4" />
+              <ExternalLink className="mr-2 h-4 w-4" />
               {t("download")}
             </button>
           </div>

--- a/apps/web/src/views/admin/tutor-applications/detail/components/ProfessionalDocumentsCard.tsx
+++ b/apps/web/src/views/admin/tutor-applications/detail/components/ProfessionalDocumentsCard.tsx
@@ -2,12 +2,12 @@
 
 import type { ProfessionalDocument } from "@mezon-tutors/shared";
 import dayjs from "dayjs";
-import { Download } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useAtomValue } from "jotai";
 import { Card, CardContent } from "@/components/ui";
+import { openSecureProxyInNewTab } from "@/lib/open-secure-proxy-in-new-tab";
 import { accessTokenAtom } from "@/store/token.atom";
-import { BASE_URL } from "@/services/api-client";
 import StatusBadge from "../../components/StatusBadge";
 
 type ProfessionalDocumentsCardProps = {
@@ -21,7 +21,7 @@ const formatDate = (date: Date | string | null | undefined) => {
   return d.isValid() ? d.format("MMM DD, YYYY") : "—";
 };
 
-function DownloadDocumentButton({
+function OpenDocumentButton({
   tutorId,
   documentId,
   label,
@@ -31,31 +31,15 @@ function DownloadDocumentButton({
   label: string;
 }) {
   const token = useAtomValue(accessTokenAtom);
-
-  const handleDownload = async () => {
-    if (!token) return;
-    const proxyPath = `/admin/tutor-profiles/${tutorId}/documents/${documentId}/image`;
-    const res = await fetch(`${BASE_URL}${proxyPath}`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    if (!res.ok) return;
-    const blob = await res.blob();
-    const ext = blob.type.split("/")[1] ?? "jpg";
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `document-${documentId}.${ext}`;
-    a.click();
-    URL.revokeObjectURL(url);
-  };
+  const proxyPath = `/admin/tutor-profiles/${tutorId}/documents/${documentId}/image`;
 
   return (
     <button
       type="button"
-      onClick={handleDownload}
+      onClick={() => void openSecureProxyInNewTab(proxyPath, token)}
       className="inline-flex items-center gap-1 text-violet-600 hover:underline"
     >
-      <Download className="h-3.5 w-3.5" />
+      <ExternalLink className="h-3.5 w-3.5" />
       {label}
     </button>
   );
@@ -107,7 +91,7 @@ export default function ProfessionalDocumentsCard({
                     </td>
                     <td className="py-3">
                       {doc.hasFile ? (
-                        <DownloadDocumentButton
+                        <OpenDocumentButton
                           tutorId={tutorId}
                           documentId={doc.id}
                           label={t("openFile")}

--- a/apps/web/src/views/admin/tutor-applications/detail/components/ProfessionalDocumentsCard.tsx
+++ b/apps/web/src/views/admin/tutor-applications/detail/components/ProfessionalDocumentsCard.tsx
@@ -2,13 +2,17 @@
 
 import type { ProfessionalDocument } from "@mezon-tutors/shared";
 import dayjs from "dayjs";
-import { ExternalLink } from "lucide-react";
+import { Download } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useAtomValue } from "jotai";
 import { Card, CardContent } from "@/components/ui";
+import { accessTokenAtom } from "@/store/token.atom";
+import { BASE_URL } from "@/services/api-client";
 import StatusBadge from "../../components/StatusBadge";
 
 type ProfessionalDocumentsCardProps = {
   documents: ProfessionalDocument[];
+  tutorId: string;
 };
 
 const formatDate = (date: Date | string | null | undefined) => {
@@ -17,8 +21,49 @@ const formatDate = (date: Date | string | null | undefined) => {
   return d.isValid() ? d.format("MMM DD, YYYY") : "—";
 };
 
+function DownloadDocumentButton({
+  tutorId,
+  documentId,
+  label,
+}: {
+  tutorId: string;
+  documentId: string;
+  label: string;
+}) {
+  const token = useAtomValue(accessTokenAtom);
+
+  const handleDownload = async () => {
+    if (!token) return;
+    const proxyPath = `/admin/tutor-profiles/${tutorId}/documents/${documentId}/image`;
+    const res = await fetch(`${BASE_URL}${proxyPath}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const ext = blob.type.split("/")[1] ?? "jpg";
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `document-${documentId}.${ext}`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleDownload}
+      className="inline-flex items-center gap-1 text-violet-600 hover:underline"
+    >
+      <Download className="h-3.5 w-3.5" />
+      {label}
+    </button>
+  );
+}
+
 export default function ProfessionalDocumentsCard({
   documents,
+  tutorId,
 }: ProfessionalDocumentsCardProps) {
   const t = useTranslations(
     "AdminTutorApplicationDetail.sections.documents.professionalDocuments",
@@ -61,16 +106,12 @@ export default function ProfessionalDocumentsCard({
                       {formatDate(doc.uploadedAt)}
                     </td>
                     <td className="py-3">
-                      {doc.fileKey ? (
-                        <a
-                          href={doc.fileKey}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="inline-flex items-center gap-1 text-violet-600 hover:underline"
-                        >
-                          <ExternalLink className="h-3.5 w-3.5" />
-                          {t("openFile")}
-                        </a>
+                      {doc.hasFile ? (
+                        <DownloadDocumentButton
+                          tutorId={tutorId}
+                          documentId={doc.id}
+                          label={t("openFile")}
+                        />
                       ) : (
                         "—"
                       )}

--- a/apps/web/src/views/admin/tutor-applications/detail/index.tsx
+++ b/apps/web/src/views/admin/tutor-applications/detail/index.tsx
@@ -189,8 +189,8 @@ export default function AdminTutorApplicationDetailView({
         <div className="space-y-5 lg:col-span-2">
           <PersonalInfoCard profile={profile} />
           <VideoBioCard profile={profile} />
-          <IdentityVerificationCard verification={identityVerification} />
-          <ProfessionalDocumentsCard documents={professionalDocuments} />
+          <IdentityVerificationCard verification={identityVerification} tutorId={profile.id} />
+          <ProfessionalDocumentsCard documents={professionalDocuments} tutorId={profile.id} />
           <AvailabilityCard profile={profile} availability={availability} />
         </div>
         <div className="space-y-5">

--- a/apps/web/src/views/main/become-tutor/availability-page/index.tsx
+++ b/apps/web/src/views/main/become-tutor/availability-page/index.tsx
@@ -45,6 +45,7 @@ import {
   emptySlotsByDay,
   readAvailabilityDraftToLocalSlots,
   writeLocalSlotsToAvailabilityDraftUtc,
+  EXISTING_SECURE_FILE,
 } from '@mezon-tutors/shared';
 import {
   useSubmitTutorProfileMutation,
@@ -57,6 +58,12 @@ import type { SubmitTutorProfileDto, TimeSlot } from '@mezon-tutors/shared';
 
 const CURRENT_STEP = BECOME_TUTOR_STEPS.AVAILABILITY;
 const PROGRESS_PERCENT = calculateStepProgress(CURRENT_STEP);
+
+function resolvePublicIdForSubmit(publicId: string | null | undefined): string | undefined {
+  const trimmed = publicId?.trim();
+  if (!trimmed || trimmed === EXISTING_SECURE_FILE) return undefined;
+  return trimmed;
+}
 
 type AvailabilityFormValues = {
   hourlyRate: string;
@@ -307,17 +314,19 @@ export default function AvailabilityPage() {
       subject: about.subject,
       languages,
       avatar: photo.photo?.uploadedUrl || DEFAULT_AVATAR_URL,
-      identityPhotoUrl: photo.identity?.uploadedUrl ?? '',
+      identityPhotoPublicId: resolvePublicIdForSubmit(photo.identity?.publicId),
       headline: photo.headline,
       motivate: photo.motivate,
       introduce: photo.introduce,
       teachingCertificateName: certification.teachingCertificate.name,
       teachingYear: certification.teachingCertificate.year,
-      teachingCertificateFileUrl: certification.teachingCertificate.file?.uploadedUrl ?? '',
+      teachingCertificatePublicId: resolvePublicIdForSubmit(
+        certification.teachingCertificate.file?.publicId,
+      ),
       university: certification.higherEducation.university,
       degree: certification.higherEducation.degree,
       specialization: certification.higherEducation.specialization,
-      educationFileUrl: certification.higherEducation.file?.uploadedUrl ?? '',
+      educationPublicId: resolvePublicIdForSubmit(certification.higherEducation.file?.publicId),
       videoUrl: video.videoLink,
       pricePerHour: Number.parseFloat(hourlyRate) || 0,
       currency,

--- a/apps/web/src/views/main/become-tutor/certification-page/index.tsx
+++ b/apps/web/src/views/main/become-tutor/certification-page/index.tsx
@@ -11,7 +11,7 @@ import { Input, Label, YearPicker } from "@/components/ui";
 import { BadgeCheck, Wallet, Info } from "lucide-react";
 import UploadFile from "@/components/common/UploadFile";
 import { tutorProfileCertificationAtom, markStepCompletedAtom, tutorProfileLastSavedAtAtom, defaultCertificationState } from "@/store";
-import { CLOUDINARY_FOLDER, MAX_FILE_SIZE_MB, BECOME_TUTOR_STEPS, calculateStepProgress, ACCEPT_FILE_TYPES } from "@mezon-tutors/shared";
+import { CLOUDINARY_FOLDER, EXISTING_SECURE_FILE, MAX_FILE_SIZE_MB, BECOME_TUTOR_STEPS, calculateStepProgress, ACCEPT_FILE_TYPES } from "@mezon-tutors/shared";
 import { cloudinaryService } from "@/services";
 import { BecomeTutorSection, BecomeTutorShell } from "../_shared/BecomeTutorShell";
 
@@ -60,21 +60,21 @@ export default function CertificationPage() {
           }
         };
 
-        const hasTeaching = data.teachingCertificateFile !== null || !!certificationMerged.teachingCertificate.file.dataUrl || !!certificationMerged.teachingCertificate.file.uploadedUrl;
+        const hasTeaching = data.teachingCertificateFile !== null || !!certificationMerged.teachingCertificate.file.dataUrl || !!certificationMerged.teachingCertificate.file.publicId;
         if (!hasTeaching) {
           ctx.addIssue({ path: ["teachingCertificateFile"], code: "custom", message: t("validation.certificateFileRequired") });
         } else if (data.teachingCertificateFile) {
           validateFile(data.teachingCertificateFile, "teachingCertificateFile", t("validation.certificateFileInvalidType"), t("validation.certificateFileTooLarge", { max: MAX_FILE_SIZE_MB }));
         }
 
-        const hasEducation = data.educationFile !== null || !!certificationMerged.higherEducation.file.dataUrl || !!certificationMerged.higherEducation.file.uploadedUrl;
+        const hasEducation = data.educationFile !== null || !!certificationMerged.higherEducation.file.dataUrl || !!certificationMerged.higherEducation.file.publicId;
         if (!hasEducation) {
           ctx.addIssue({ path: ["educationFile"], code: "custom", message: t("validation.educationFileRequired") });
         } else if (data.educationFile) {
           validateFile(data.educationFile, "educationFile", t("validation.educationFileInvalidType"), t("validation.educationFileTooLarge", { max: MAX_FILE_SIZE_MB }));
         }
       }),
-    [t, certificationMerged.teachingCertificate.file.dataUrl, certificationMerged.teachingCertificate.file.uploadedUrl, certificationMerged.higherEducation.file.dataUrl, certificationMerged.higherEducation.file.uploadedUrl]
+    [t, certificationMerged.teachingCertificate.file.dataUrl, certificationMerged.teachingCertificate.file.publicId, certificationMerged.higherEducation.file.dataUrl, certificationMerged.higherEducation.file.publicId]
   );
 
   type CertificationFormValues = z.infer<typeof certificationSchema>;
@@ -130,7 +130,7 @@ export default function CertificationPage() {
         }));
         setLastSavedAt(new Date().toISOString());
 
-        const uploadedFile = await cloudinaryService.uploadFileWithSignature(file, CLOUDINARY_FOLDER.TUTOR_CERTIFICATE, "auto");
+        const uploadedFile = await cloudinaryService.uploadPrivateFile(file, CLOUDINARY_FOLDER.TUTOR_CERTIFICATE, "auto");
         if (teachingUploadSeqRef.current !== seq) return;
         setCertification((prev) => ({ 
           ...prev, 
@@ -138,12 +138,12 @@ export default function CertificationPage() {
             ...prev.teachingCertificate, 
             file: { 
               ...(prev.teachingCertificate?.file || {}), 
-              uploadedUrl: uploadedFile.secureUrl, 
+              uploadedUrl: null,
               publicId: uploadedFile.publicId 
             } 
           } 
         }));
-        if (previousPublicId && previousPublicId !== uploadedFile.publicId) {
+        if (previousPublicId && previousPublicId !== uploadedFile.publicId && previousPublicId !== EXISTING_SECURE_FILE) {
           void cloudinaryService.deleteFile(previousPublicId).catch(() => null);
         }
         await form.trigger("teachingCertificateFile");
@@ -191,7 +191,7 @@ export default function CertificationPage() {
         }));
         setLastSavedAt(new Date().toISOString());
 
-        const uploadedFile = await cloudinaryService.uploadFileWithSignature(file, CLOUDINARY_FOLDER.TUTOR_DIPLOMA, "auto");
+        const uploadedFile = await cloudinaryService.uploadPrivateFile(file, CLOUDINARY_FOLDER.TUTOR_DIPLOMA, "auto");
         if (educationUploadSeqRef.current !== seq) return;
         setCertification((prev) => ({ 
           ...prev, 
@@ -199,12 +199,12 @@ export default function CertificationPage() {
             ...prev.higherEducation, 
             file: { 
               ...(prev.higherEducation?.file || {}), 
-              uploadedUrl: uploadedFile.secureUrl, 
+              uploadedUrl: null,
               publicId: uploadedFile.publicId 
             } 
           } 
         }));
-        if (previousPublicId && previousPublicId !== uploadedFile.publicId) {
+        if (previousPublicId && previousPublicId !== uploadedFile.publicId && previousPublicId !== EXISTING_SECURE_FILE) {
           void cloudinaryService.deleteFile(previousPublicId).catch(() => null);
         }
         await form.trigger("educationFile");
@@ -222,12 +222,12 @@ export default function CertificationPage() {
     const { teachingCertificateFile: _tcf, educationFile: _ef, certificateType, ...textFields } = values;
     if (teachingUploading || educationUploading) return;
 
-    if (!certificationMerged.teachingCertificate.file.uploadedUrl) {
+    if (!certificationMerged.teachingCertificate.file.publicId) {
       form.setError("teachingCertificateFile", { type: "manual", message: t("validation.certificateUploadFailed") });
       return;
     }
 
-    if (!certificationMerged.higherEducation.file.uploadedUrl) {
+    if (!certificationMerged.higherEducation.file.publicId) {
       form.setError("educationFile", { type: "manual", message: t("validation.educationUploadFailed") });
       return;
     }

--- a/apps/web/src/views/main/become-tutor/final-page/index.tsx
+++ b/apps/web/src/views/main/become-tutor/final-page/index.tsx
@@ -12,6 +12,7 @@ import {
   VerificationStatus,
   PROFESSIONAL_DOCUMENT_TYPE,
   normalizeUtcAvailabilityRows,
+  EXISTING_SECURE_FILE,
 } from '@mezon-tutors/shared';
 import { useGetMyProfile } from '@/services';
 import {
@@ -108,18 +109,6 @@ export default function FinalPage() {
     const profile = result.profile;
     setIsEditingRejected(true);
 
-    const extractFileName = (url: string) => {
-      if (!url) return '';
-      try {
-        const parts = url.split('/');
-        const lastPart = parts[parts.length - 1];
-        const fileNameWithExt = lastPart.split('?')[0];
-        return decodeURIComponent(fileNameWithExt);
-      } catch {
-        return 'uploaded-file';
-      }
-    };
-
     const languages = profile.languages.map((l: any) => l.languageCode).join(', ');
     const proficiencies = profile.languages.map((l: any) => l.proficiency).join(', ');
 
@@ -139,11 +128,11 @@ export default function FinalPage() {
 
     setPhoto({
       photo: { uploadedUrl: profile.avatar, dataUrl: '', publicId: '', fileName: '' },
-      identity: { 
-        uploadedUrl: profile.identityVerification?.fileKey || '', 
-        dataUrl: '', 
-        publicId: '', 
-        fileName: extractFileName(profile.identityVerification?.fileKey || '')
+      identity: {
+        uploadedUrl: null,
+        publicId: profile.identityVerification?.hasFile ? EXISTING_SECURE_FILE : null,
+        dataUrl: '',
+        fileName: profile.identityVerification?.hasFile ? 'uploaded-document' : '',
       },
       headline: profile.headline,
       motivate: profile.motivate,
@@ -154,22 +143,22 @@ export default function FinalPage() {
       teachingCertificate: {
         name: teachingCertDoc?.name || '',
         year: teachingCertDoc?.yearOfComplete ? String(teachingCertDoc.yearOfComplete) : '',
-        file: { 
-          uploadedUrl: teachingCertDoc?.fileKey || '', 
-          dataUrl: '', 
-          publicId: '', 
-          fileName: extractFileName(teachingCertDoc?.fileKey || '')
+        file: {
+          uploadedUrl: null,
+          publicId: teachingCertDoc?.hasFile ? EXISTING_SECURE_FILE : null,
+          dataUrl: '',
+          fileName: teachingCertDoc?.hasFile ? teachingCertDoc.name || 'uploaded-document' : '',
         },
       },
       higherEducation: {
         university: educationDoc?.institution || '',
         degree: educationDoc?.name || '',
         specialization: educationDoc?.specialization || '',
-        file: { 
-          uploadedUrl: educationDoc?.fileKey || '', 
-          dataUrl: '', 
-          publicId: '', 
-          fileName: extractFileName(educationDoc?.fileKey || '')
+        file: {
+          uploadedUrl: null,
+          publicId: educationDoc?.hasFile ? EXISTING_SECURE_FILE : null,
+          dataUrl: '',
+          fileName: educationDoc?.hasFile ? educationDoc.name || 'uploaded-document' : '',
         },
       },
     });

--- a/apps/web/src/views/main/become-tutor/photo-page/index.tsx
+++ b/apps/web/src/views/main/become-tutor/photo-page/index.tsx
@@ -19,6 +19,7 @@ import {
   calculateStepProgress,
   CLOUDINARY_FOLDER,
   DEFAULT_AVATAR_URL,
+  EXISTING_SECURE_FILE,
   MAX_IMAGE_SIZE_MB,
 } from "@mezon-tutors/shared";
 import { Input, Label } from "@/components/ui";
@@ -51,9 +52,7 @@ export default function PhotoPage() {
   const [, markStepCompleted] = useAtom(markStepCompletedAtom);
   const currentUser = useAtomValue(userAtom);
   const [previewIdentityUrl, setPreviewIdentityUrl] = useState<string | null>(
-    tutorProfilePhoto.identity?.dataUrl ||
-      tutorProfilePhoto.identity?.uploadedUrl ||
-      null,
+    tutorProfilePhoto.identity?.dataUrl || null,
   );
   const [isUploading, setIsUploading] = useState(false);
   const identityUploadSeqRef = useRef(0);
@@ -102,7 +101,7 @@ export default function PhotoPage() {
           const hasIdentity =
             data.identityPhotoFile !== null ||
             !!tutorProfilePhoto.identity?.dataUrl ||
-            !!tutorProfilePhoto.identity?.uploadedUrl;
+            !!tutorProfilePhoto.identity?.publicId;
           if (!hasIdentity) {
             ctx.addIssue({
               path: ["identityPhotoFile"],
@@ -116,7 +115,7 @@ export default function PhotoPage() {
     [
       t,
       tutorProfilePhoto.identity?.dataUrl,
-      tutorProfilePhoto.identity?.uploadedUrl,
+      tutorProfilePhoto.identity?.publicId,
       allowedImageExt,
     ],
   );
@@ -145,15 +144,8 @@ export default function PhotoPage() {
   } = form;
 
   useEffect(() => {
-    setPreviewIdentityUrl(
-      tutorProfilePhoto.identity?.dataUrl ||
-        tutorProfilePhoto.identity?.uploadedUrl ||
-        null,
-    );
-  }, [
-    tutorProfilePhoto.identity?.dataUrl,
-    tutorProfilePhoto.identity?.uploadedUrl,
-  ]);
+    setPreviewIdentityUrl(tutorProfilePhoto.identity?.dataUrl || null);
+  }, [tutorProfilePhoto.identity?.dataUrl]);
 
   useEffect(() => {
     const avatarUrl = currentUser?.avatar || DEFAULT_AVATAR_URL;
@@ -217,7 +209,7 @@ export default function PhotoPage() {
           setPreviewIdentityUrl(dataUrl);
           setLastSavedAt(new Date().toISOString());
 
-          const uploadedFile = await cloudinaryService.uploadFileWithSignature(
+          const uploadedFile = await cloudinaryService.uploadPrivateFile(
             file,
             CLOUDINARY_FOLDER.TUTOR_IDENTITY,
             "image",
@@ -227,11 +219,15 @@ export default function PhotoPage() {
             ...prev,
             identity: {
               ...prev.identity,
-              uploadedUrl: uploadedFile.secureUrl,
+              uploadedUrl: null,
               publicId: uploadedFile.publicId,
             },
           }));
-          if (previousPublicId && previousPublicId !== uploadedFile.publicId) {
+          if (
+            previousPublicId &&
+            previousPublicId !== uploadedFile.publicId &&
+            previousPublicId !== EXISTING_SECURE_FILE
+          ) {
             void cloudinaryService.deleteFile(previousPublicId).catch(() => null);
           }
           await form.trigger("identityPhotoFile");
@@ -263,7 +259,7 @@ export default function PhotoPage() {
     const { identityPhotoFile: _identityPhotoFile, ...textValues } = values;
     if (isUploading) return;
 
-    if (!tutorProfilePhoto.identity?.uploadedUrl) {
+    if (!tutorProfilePhoto.identity?.publicId) {
       form.setError("identityPhotoFile", {
         type: "manual",
         message: t("validation.identityUploadFailed"),

--- a/apps/web/src/views/main/tutor-profile/utils.ts
+++ b/apps/web/src/views/main/tutor-profile/utils.ts
@@ -36,11 +36,11 @@ export type MyTutorProfileRecord = {
   ratingAverage: string | number;
   languages: TutorLanguageRow[];
   availability: Array<{ dayOfWeek: number; startTime: string; endTime: string }>;
-  identityVerification?: { fileKey: string } | null;
+  identityVerification?: { hasFile: boolean } | null;
   professionalDocuments?: Array<{
     type: string;
     name: string;
-    fileKey: string;
+    hasFile: boolean;
     institution?: string | null;
     specialization?: string | null;
     yearOfComplete?: number | null;

--- a/packages/db/scripts/001-migrate-file-key-to-public-id.sql
+++ b/packages/db/scripts/001-migrate-file-key-to-public-id.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+-- professional_documents
+UPDATE professional_documents
+SET file_key = regexp_replace(
+  regexp_replace(
+    file_key,
+    '^https://res\.cloudinary\.com/[^/]+/(image|video|raw)/upload/(v[0-9]+/)?',
+    ''
+  ),
+  '\.[a-zA-Z0-9]+$', ''
+)
+WHERE file_key ~ '^https://res\.cloudinary\.com/';
+
+-- identity_verification
+UPDATE identity_verification
+SET file_key = regexp_replace(
+  regexp_replace(
+    file_key,
+    '^https://res\.cloudinary\.com/[^/]+/(image|video|raw)/upload/(v[0-9]+/)?',
+    ''
+  ),
+  '\.[a-zA-Z0-9]+$', ''
+)
+WHERE file_key ~ '^https://res\.cloudinary\.com/';
+
+COMMIT;
+
+-- Verify (should return 0 rows with cloudinary URLs left):
+-- SELECT id, file_key FROM professional_document WHERE file_key ~ '^https://';
+-- SELECT id, file_key FROM identity_verification WHERE file_key ~ '^https://';

--- a/packages/shared/src/constants/cloudinary.ts
+++ b/packages/shared/src/constants/cloudinary.ts
@@ -11,3 +11,6 @@ export const CLOUDINARY_FOLDER = {
 
 export const MAX_IMAGE_SIZE_MB = 5;
 export const MAX_FILE_SIZE_MB = 15;
+
+/** Sentinel in become-tutor draft when document already exists on server (re-edit flow). */
+export const EXISTING_SECURE_FILE = '__existing__' as const;

--- a/packages/shared/src/types/tutor-application.ts
+++ b/packages/shared/src/types/tutor-application.ts
@@ -79,7 +79,7 @@ export type ProfessionalDocument = {
   uploadedAt: Date;
   specialization: string | null;
   yearOfComplete: number | null;
-  fileKey: string;
+  hasFile: boolean;
   reviewedAt: Date | null;
   institution: string | null;
 };
@@ -94,7 +94,7 @@ export type IdentityVerification = {
   notExpired: boolean;
   photoClarity: boolean;
   uploadedAt: Date;
-  fileKey: string;
+  hasFile: boolean;
   reviewedAt: Date | null;
 };
 

--- a/packages/shared/src/types/tutor-profile.ts
+++ b/packages/shared/src/types/tutor-profile.ts
@@ -34,19 +34,19 @@ export interface SubmitTutorProfileDto {
   languages: TutorLanguageDto[]
 
   avatar: string
-  identityPhotoUrl: string
+  identityPhotoPublicId?: string
   headline: string
   motivate: string
   introduce: string
 
   teachingCertificateName: string
   teachingYear: string
-  teachingCertificateFileUrl: string
+  teachingCertificatePublicId?: string
 
   university: string
   degree: string
   specialization: string
-  educationFileUrl: string
+  educationPublicId?: string
 
   videoUrl: string
 
@@ -125,7 +125,7 @@ export type ProfessionalDocument = {
   uploadedAt: Date
   specialization: string | null
   yearOfComplete: number | null
-  fileKey: string
+  hasFile: boolean
   reviewedAt: Date | null
   institution: string | null
 }
@@ -140,7 +140,7 @@ export type IdentityVerification = {
   notExpired: boolean
   photoClarity: boolean
   uploadedAt: Date
-  fileKey: string
+  hasFile: boolean
   reviewedAt: Date | null
 }
 


### PR DESCRIPTION
# Tài liệu tham khảo: Bảo mật ảnh tài liệu nhạy cảm qua Backend Proxy

> Triển khai pattern **Backend Proxy** trên Mezon Tutors — áp dụng cho ảnh CCCD, chứng chỉ gia sư và các tài liệu nhạy cảm khác lưu trên Cloudinary.

**Mục tiêu:** Người ngoài **không xem được** ảnh qua link trực tiếp (kể cả tab ẩn danh), trong khi **admin đăng nhập vẫn xem được** trên hệ thống.


## 1. Vấn đề cần giải quyết

Khi upload ảnh lên Cloudinary theo cách thông thường (`type: upload`), Cloudinary trả về **`secure_url`** — một link công khai. Ai có link đều mở được, không cần đăng nhập.

| Hiện tượng | Nguyên nhân |
|---|---|
| Tab ẩn danh vẫn xem được ảnh | `secure_url` là URL public trên CDN |
| URL lưu thẳng trong database | Cột `file_key` = full URL Cloudinary |
| Admin UI dùng `<img src="https://res.cloudinary.com/...">` | Trình duyệt tải ảnh trực tiếp từ CDN |
| DevTools / API JSON lộ link | Response trả `fileKey` = URL đầy đủ |

**Yêu cầu sau khi triển khai:**

- Ảnh vẫn lưu trên Cloudinary (không đổi storage).
- Admin xem được qua giao diện quản trị.
- Client **không bao giờ** nhận URL Cloudinary thật.
- Link trực tiếp **không còn hoạt động** (sau khi hoàn tất toàn bộ các bước).

---

## 2. Ý tưởng cốt lõi (đọc trước khi code)

### 2.1. Database lưu gì?

Database **không lưu link web**, chỉ lưu **mã định danh nội bộ** gọi là **`publicId`**:

```
mezon-tutor/tutor-diploma/bdl3bamqlxtbhdriiqq9
```

Đây là **“số hồ sơ trong kho Cloudinary”**, không phải địa chỉ mà trình duyệt mở trực tiếp được.

| Lưu URL đầy đủ (cách cũ) | Lưu publicId (cách mới) |
|---|---|
| `https://res.cloudinary.com/.../bdl3bamqlxtbhdriiqq9.png` | `mezon-tutor/tutor-diploma/bdl3bamqlxtbhdriiqq9` |
| Ai copy URL → xem được | URL không tồn tại trong DB/API |

### 2.2. Admin xem ảnh bằng cách nào?

Admin **không** dùng `publicId` làm `src` của thẻ `<img>`. Thay vào đó:

1. Admin đăng nhập → có **JWT token** (thẻ nhân viên).
2. Giao diện gọi **API nội bộ** (proxy): *“Cho tôi xem ảnh hồ sơ này”*.
3. **Backend** kiểm tra quyền admin.
4. Backend tra DB → lấy `publicId`.
5. Backend dùng **Cloudinary API Secret** (chìa khóa chỉ server giữ) fetch ảnh từ Cloudinary.
6. Backend **stream** (gửi thẳng) dữ liệu ảnh về trình duyệt — **không** gửi link Cloudinary.
7. Frontend tạo URL tạm `blob:...` để hiển thị.

```
┌─────────────┐         ┌─────────────┐         ┌──────────────┐         ┌─────────────┐
│   Admin     │         │   Backend   │         │  Database    │         │ Cloudinary  │
│  (browser)  │         │  (NestJS)   │         │              │         │  (kho ảnh)  │
└──────┬──────┘         └──────┬──────┘         └──────┬───────┘         └──────┬──────┘
       │  ① Xem ảnh + JWT      │                       │                        │
       │──────────────────────>│                       │                        │
       │                       │  ② Kiểm tra admin     │                        │
       │                       │  ③ Lấy publicId       │                        │
       │                       │──────────────────────>│                        │
       │                       │<──────────────────────│                        │
       │                       │  ④ Fetch ảnh (publicId + Secret)              │
       │                       │──────────────────────────────────────────────>│
       │                       │<──────────────────────────────────────────────│
       │  ⑤ Nhận bytes ảnh     │                       │                        │
       │<──────────────────────│                       │                        │
       │  ⑥ Hiển thị blob:...   │                       │                        │
       ▼                       │                       │                        │
```

**User ngoài** không có JWT admin, không có API Secret → không thể lặp lại luồng trên.

### 2.3. Ba khái niệm cần nhớ

| Khái niệm | Là gì? | Ai nắm giữ? |
|---|---|---|
| **publicId** | Mã file trên Cloudinary | Database (server đọc nội bộ) |
| **API Secret** | Chìa khóa truy cập file private | Chỉ backend (env variable) |
| **JWT token** | Chứng minh user đã đăng nhập + role | Trình duyệt admin (sau login) |

---

## 3. Kiến trúc 4 lớp bảo vệ

Giải pháp gồm **4 lớp** bổ trợ nhau. Triển khai đủ cả 4 mới đạt bảo mật hoàn chỉnh.

```mermaid
flowchart TB
  subgraph L1["Lớp 1 — Cloudinary"]
    PRIV["Upload type: private<br/>Link CDN không truy cập trực tiếp"]
  end

  subgraph L2["Lớp 2 — Database"]
    PID["file_key = publicId<br/>Không lưu secure_url"]
  end

  subgraph L3["Lớp 3 — API Backend"]
    HIDE["Response: hasFile<br/>Không trả URL ra client"]
    PROXY["GET /admin/.../image<br/>JWT + AdminGuard"]
  end

  subgraph L4["Lớp 4 — Frontend Admin"]
    SEC["SecureImage: fetch + JWT → blob URL"]
  end

  L1 --> L2 --> L3 --> L4
```

| Lớp | Việc cần làm | Tác dụng |
|---|---|---|
| **1. Cloudinary** | Upload qua backend với `type: 'private'` | CDN từ chối truy cập trực tiếp |
| **2. Database** | `file_key` chỉ chứa `publicId` | Không lộ URL trong DB |
| **3. API** | Proxy stream ảnh + ẩn URL khỏi JSON | Chỉ admin có quyền lấy bytes ảnh |
| **4. Frontend** | `SecureImage` dùng blob URL | DOM không chứa link Cloudinary |

---

## 4. So sánh luồng trước và sau

### 4.1. Cách cũ (không bảo mật)

```mermaid
sequenceDiagram
  participant Tutor as Gia sư (FE)
  participant CLD as Cloudinary (public)
  participant DB as Database
  participant Admin as Admin (FE)
  participant Outsider as User ngoài

  Tutor->>CLD: Upload trực tiếp
  CLD-->>Tutor: secure_url
  Tutor->>DB: Lưu URL vào file_key

  Admin->>Admin: img src = secure_url
  Note over Admin: URL lộ trên DOM

  Outsider->>CLD: Mở link trực tiếp
  CLD-->>Outsider: 200 OK
```

### 4.2. Cách mới (Backend Proxy)

```mermaid
sequenceDiagram
  participant Tutor as Gia sư (FE)
  participant API as NestJS API
  participant CLD as Cloudinary (private)
  participant DB as Database
  participant Admin as Admin (FE)
  participant Outsider as User ngoài

  Tutor->>API: POST /cloudinary/upload-private
  API->>CLD: Upload type private
  API->>DB: file_key = publicId

  Admin->>API: GET /admin/.../image + JWT
  API->>DB: Đọc publicId
  API->>CLD: Fetch server-to-server
  API-->>Admin: Stream bytes ảnh
  Admin->>Admin: blob URL tạm

  Outsider->>CLD: Link trực tiếp
  CLD-->>Outsider: 404 / Access denied
```

---

## 5. Hướng dẫn triển khai từng phần

### 5.1. Backend Proxy — Endpoint admin xem ảnh

**Tạo endpoint** chỉ admin mới gọi được:

| Method | Path | Mô tả |
|---|---|---|
| `GET` | `/api/admin/tutor-profiles/:tutorId/identity-verification/image` | Ảnh CCCD |
| `GET` | `/api/admin/tutor-profiles/:tutorId/documents/:documentId/image` | Chứng chỉ / bằng cấp |

**Guard:** `JwtAuthGuard` + `AdminGuard`.

**Xử lý trong controller:**

1. Đọc `file_key` từ bảng `identity_verification` hoặc `professional_document`.
2. Gọi `CloudinaryService.fetchPrivateAsset(fileKey)`.
3. Set header `Content-Type`, `Cache-Control: private, no-store`.
4. `res.send(buffer)` — stream bytes về client.

```mermaid
flowchart LR
  A[Admin mở trang hồ sơ] --> B[Gọi proxy API]
  B --> C{JWT + Admin?}
  C -->|Không| D[401 / 403]
  C -->|Có| E[Đọc publicId từ DB]
  E --> F[Fetch Cloudinary server-side]
  F --> G[Stream ảnh về browser]
  G --> H[blob URL — không lộ CDN]
```

**CloudinaryService cần:**

- `resolveAssetReference(fileKey)` — parse URL cũ → publicId (nếu còn data legacy).
- `fetchPrivateAsset(fileKey)` — dùng signed URL + API Secret fetch server-to-server.

---

### 5.2. Frontend Admin — Component SecureImage

**Không làm:**

```tsx
<img src="https://res.cloudinary.com/..." />
```

**Làm:**

```tsx
<SecureImage
  proxyPath={`/admin/tutor-profiles/${tutorId}/identity-verification/image`}
  alt="CCCD"
/>
```

**SecureImage hoạt động:**

1. `fetch(BASE_URL + proxyPath, { headers: { Authorization: Bearer token } })`
2. Nhận `response.blob()`
3. `URL.createObjectURL(blob)` → gán vào `<img src="blob:...">`
4. `URL.revokeObjectURL()` khi component unmount

Nút **Download** cũng fetch qua proxy, không mở tab Cloudinary.

---

### 5.3. Ẩn URL khỏi API response

Client **không cần** biết URL hay publicId. Chỉ cần biết **có file hay không**.

**Trước:**

```json
{ "fileKey": "https://res.cloudinary.com/.../abc.jpg" }
```

**Sau:**

```json
{ "hasFile": true }
```

Mapper admin và API `getMyProfile` strip `fileKey`, chỉ trả `hasFile: boolean`.

---

### 5.4. Upload private qua Backend

**Vì sao không upload từ frontend trực tiếp?**

Để set `type: 'private'` trên Cloudinary cần **API Secret** — không được expose ra browser.

**Luồng upload mới:**

```mermaid
flowchart TB
  F1[FE chọn file] --> F2[POST /cloudinary/upload-private + JWT]
  F2 --> F3[Backend upload type private]
  F3 --> F4[Trả publicId cho FE]
  F4 --> F5[Submit hồ sơ: chỉ gửi publicId]
  F5 --> F6[DB: file_key = publicId]
```

**Endpoint backend:**

```
POST /api/cloudinary/upload-private
Body: multipart/form-data (file, folder, resourceType)
Response: { publicId, resourceType, format }
```

**DTO submit hồ sơ — đổi tên field:**

| Field cũ (bỏ) | Field mới |
|---|---|
| `identityPhotoUrl` | `identityPhotoPublicId` |
| `teachingCertificateFileUrl` | `teachingCertificatePublicId` |
| `educationFileUrl` | `educationPublicId` |

Backend validate: **từ chối** nếu client gửi URL (`https://...`) thay vì publicId.

---

## 6. Xử lý dữ liệu cũ (migration)

Nếu hệ thống đã có ảnh upload theo cách cũ, cần **2 bước migration** (chạy script tự động, không sửa tay từng record).

### Bước A — Chuẩn hóa database: URL → publicId

**Mục đích:** Cột `file_key` chỉ còn publicId, không còn URL.

**Script:** `packages/db/scripts/001-migrate-file-key-to-public-id.sql`

```
https://res.cloudinary.com/.../mezon-tutor/tutor-certificate/abc.jpg
        ↓
mezon-tutor/tutor-certificate/abc
```

**Chạy:**

```bash
cd packages/db
yarn dotenv -e .env -- npx prisma db execute \
  --file scripts/001-migrate-file-key-to-public-id.sql \
  --schema prisma/schema.prisma
```

**Kiểm tra:**

```sql
SELECT id, file_key FROM professional_document LIMIT 5;
-- Kỳ vọng: mezon-tutor/tutor-certificate/xxx (không còn https://)
```

### Bước B — Chuyển asset trên Cloudinary sang private

**Mục đích:** Link CDN cũ (`https://res.cloudinary.com/...`) không còn mở được.

**Script:** `apps/api/scripts/migrate-assets-to-private.ts`

Với mỗi record trong `identity_verification` và `professional_document`:

1. Fetch asset public hiện tại (server-side).
2. Re-upload với `type: 'private'`.
3. Cập nhật `file_key` nếu publicId thay đổi.
4. Xóa bản public cũ trên Cloudinary.

**Chạy** (sau khi deploy code upload-private):

```bash
cd apps/api
yarn dotenv -e .env -- npx tsx scripts/migrate-assets-to-private.ts
```

```mermaid
flowchart LR
  subgraph DB["Chuẩn hóa Database"]
    U1[file_key = URL] --> U2[file_key = publicId]
  end

  subgraph CDN["Chuẩn hóa Cloudinary"]
    C1[Asset public] --> C2[Re-upload private]
    C2 --> C3[Xóa asset public cũ]
  end

  DB --> CDN
```

> **Lưu ý:** Bước A có thể chạy trước khi deploy code mới. Bước B cần chạy sau khi backend đã hỗ trợ upload private và proxy. Upload mới sau khi deploy đã tự động là private.

---

## 7. Ma trận hiệu quả bảo mật

| Kịch bản | Trước triển khai | Sau proxy + ẩn URL | Sau khi asset Cloudinary là private |
|---|---|---|---|
| Admin xem ảnh trên UI | ✅ (URL lộ) | ✅ (proxy + blob) | ✅ |
| JSON API lộ URL Cloudinary | ❌ Lộ | ✅ Chỉ `hasFile` | ✅ |
| DOM có `src="https://res.cloudinary..."` | ❌ Có | ✅ Không | ✅ |
| User ngoài mở link CDN trực tiếp | ❌ Xem được | ⚠️ Vẫn xem được* | ✅ 404 / denied |
| Upload mới là private | ❌ | ✅ | ✅ |

\* *Asset upload trước khi chạy script chuyển private vẫn public trên CDN cho đến khi script hoàn tất.*

---

## 8. Checklist triển khai

Thứ tự gợi ý khi implement từ đầu hoặc áp dụng vào project tương tự:

- [ ] **Proxy endpoint** admin + `JwtAuthGuard` + `AdminGuard`
- [ ] **CloudinaryService** — `fetchPrivateAsset`, `resolveAssetReference`
- [ ] **SecureImage** + cập nhật admin cards (CCCD, chứng chỉ)
- [ ] **Ẩn `fileKey`** khỏi API — trả `hasFile` thay thế
- [ ] **POST /cloudinary/upload-private** — upload qua backend
- [ ] **Frontend upload flow** — chỉ lưu/gửi `publicId`
- [ ] **DTO submit** — đổi sang `*PublicId` fields
- [ ] **Migration DB** — script chuẩn hóa URL → publicId
- [ ] **Migration Cloudinary** — script chuyển asset sang private
- [ ] **Verify:** link CDN cũ → 404; admin proxy → 200; DevTools không thấy URL Cloudinary

---

## 9. File tham chiếu trong codebase

| File | Vai trò |
|---|---|
| `apps/api/src/modules/tutor-application/tutor-application.controller.ts` | Proxy endpoints admin |
| `apps/api/src/modules/cloudinary/cloudinary.service.ts` | Upload private, fetch asset |
| `apps/api/src/modules/cloudinary/cloudinary.controller.ts` | `POST upload-private` |
| `apps/api/src/modules/tutor-application/tutor-application.mapper.ts` | Trả `hasFile` |
| `apps/api/src/modules/tutor-profile/tutor-profile.service.ts` | Sanitize profile, lưu publicId |
| `apps/web/src/components/ui/SecureImage.tsx` | Hiển thị ảnh qua proxy |
| `apps/web/src/services/cloudinary/cloudinary.service.ts` | FE gọi upload-private |
| `packages/shared/src/types/tutor-profile.ts` | Types `hasFile`, `*PublicId` |
| `packages/db/scripts/001-migrate-file-key-to-public-id.sql` | Migration DB |
| `apps/api/scripts/migrate-assets-to-private.ts` | Migration Cloudinary → private |
| `packages/db/scripts/README-secure-files-migration.md` | Hướng dẫn chạy script migration |

---

## Tóm tắt một câu

**Database lưu “số hồ sơ” (publicId), không lưu link web. Admin xem ảnh bằng cách gọi API có xác thực; server dùng publicId + API Secret lấy file từ Cloudinary rồi gửi bytes về trình duyệt. User ngoài không có quyền và không có chìa khóa nên không xem được — kể cả khi từng biết link CDN cũ (sau khi asset đã chuyển sang private).**
